### PR TITLE
feat(workflows): sync improvements from theme-management

### DIFF
--- a/.github/workflows/reusable-auto-merge-image-updater.yml
+++ b/.github/workflows/reusable-auto-merge-image-updater.yml
@@ -1,22 +1,29 @@
 name: Auto-merge Image Updater PRs (Reusable)
 
-# Auto-merges pull requests created by ArgoCD Image Updater.
-# Approves using AUTO_MERGE_PAT (or GITHUB_TOKEN fallback),
-# then enables auto-merge so it lands once status checks pass.
+# Called from push-triggered workflows on image-updater/* branches.
+# Creates the PR, approves, and enables auto-merge in a single job to avoid
+# GITHUB_TOKEN anti-recursion: actions using GITHUB_TOKEN don't trigger new
+# workflow runs, so a two-job design (push → create PR → pull_request → merge)
+# never fires the second job.
+#
+# Calling workflow should trigger on:
+#   push:
+#     branches:
+#       - 'image-updater-**'
 
 on:
   workflow_call:
     inputs:
-      branch-prefix:
-        description: 'Branch prefix used by Image Updater PRs'
-        required: false
-        type: string
-        default: 'image-updater/'
       merge-method:
         description: 'Merge method: merge, squash, or rebase'
         required: false
         type: string
         default: 'squash'
+      pr-title:
+        description: 'Pull request title'
+        required: false
+        type: string
+        default: 'build: automatic image update'
     secrets:
       AUTO_MERGE_PAT:
         description: 'PAT for approving the PR (needs a different user from the PR author)'
@@ -27,23 +34,39 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-merge:
-    if: startsWith(github.head_ref, inputs.branch-prefix)
+  create-and-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Create Pull Request
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ github.ref_name }}" \
+            --title "${{ inputs.pr-title }}" \
+            --body "Automated image update by argocd-image-updater.
+
+          Branch: \`${{ github.ref_name }}\`" \
+            2>&1) || true
+
+          if echo "$PR_URL" | grep -q "already exists"; then
+            PR_URL=$(gh pr view "${{ github.ref_name }}" --json url -q .url)
+          fi
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Created/found PR: $PR_URL"
 
       - name: Approve PR
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
-        run: gh pr review "${{ github.event.pull_request.number }}" --approve
+        run: gh pr review --approve "${{ github.ref_name }}"
 
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr merge "${{ github.event.pull_request.number }}" \
-            --auto \
-            --${{ inputs.merge-method }} \
-            --base main
+        run: gh pr merge --auto --${{ inputs.merge-method }} "${{ github.ref_name }}"

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: 'CRITICAL,HIGH'
+      enable-signing:
+        description: 'Sign release images with cosign (keyless/Sigstore)'
+        required: false
+        type: boolean
+        default: true
     outputs:
       version:
         description: 'Released version'
@@ -61,6 +66,9 @@ on:
       promoted:
         description: 'true if promoted from pre-built image, false if rebuilt'
         value: ${{ jobs.release.outputs.promoted }}
+      signed:
+        description: 'true if signed with cosign'
+        value: ${{ jobs.release.outputs.signed }}
 
 permissions:
   contents: read
@@ -76,6 +84,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tags: ${{ steps.meta.outputs.tags }}
       promoted: ${{ steps.pr-image.outputs.exists }}
+      signed: ${{ steps.cosign-sign.outputs.signed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -166,6 +175,29 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      # ---- Container signing (keyless / Sigstore) -----------------------------
+      - name: Install cosign
+        if: inputs.enable-signing
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Capture release image digest
+        if: inputs.enable-signing
+        id: release-digest
+        run: |
+          FIRST_TAG=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)
+          DIGEST=$(docker buildx imagetools inspect "${FIRST_TAG}" --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=ghcr.io/${{ inputs.image-name }}@${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Sign release image with cosign (keyless)
+        if: inputs.enable-signing
+        id: cosign-sign
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign "${{ steps.release-digest.outputs.image }}"
+          echo "signed=true" >> $GITHUB_OUTPUT
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
         with:
@@ -185,13 +217,30 @@ jobs:
         if: always()
         run: |
           PROMOTED="${{ steps.pr-image.outputs.exists }}"
+          SIGNED="${{ steps.cosign-sign.outputs.signed }}"
+          DIGEST="${{ steps.release-digest.outputs.digest }}"
           echo "## Container Release: \`${{ inputs.image-name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: \`${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           if [ "$PROMOTED" = "true" ]; then
-            echo "- **Method**: ✅ Promoted from pre-built PR image (fast path — no rebuild)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Method**: Promoted from pre-built PR image (fast path)" >> $GITHUB_STEP_SUMMARY
             echo "- **Source**: \`${{ steps.version.outputs.next_image }}\`" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- **Method**: 🔨 Full rebuild (fallback — pre-built image not found)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Method**: Full rebuild (fallback)" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "$SIGNED" = "true" ]; then
+            echo "- **Signing**: Signed with cosign (keyless/Sigstore)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Digest**: \`${DIGEST}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **Rekor**: [transparency log](https://search.sigstore.dev/?hash=${DIGEST})" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "<details><summary>Verify signature</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```bash' >> $GITHUB_STEP_SUMMARY
+            echo "cosign verify \\" >> $GITHUB_STEP_SUMMARY
+            echo "  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \\" >> $GITHUB_STEP_SUMMARY
+            echo "  --certificate-identity-regexp='https://github.com/ForumViriumHelsinki/' \\" >> $GITHUB_STEP_SUMMARY
+            echo "  ghcr.io/${{ inputs.image-name }}@${DIGEST}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi
           echo "- **Tags**:" >> $GITHUB_STEP_SUMMARY
           echo '${{ steps.meta.outputs.tags }}' | while read -r tag; do

--- a/.github/workflows/reusable-fix-release-conflicts.yml
+++ b/.github/workflows/reusable-fix-release-conflicts.yml
@@ -1,0 +1,110 @@
+name: Fix Release-Please Conflicts (Reusable)
+
+# When the release-please PR gets merge conflicts (typically from rapid commits
+# to main that change CHANGELOG.md, package.json, or the manifest), this workflow
+# deletes the stale branch and retriggers release-please to recreate it cleanly.
+#
+# Root cause: release-please creates a branch modifying 3 files (CHANGELOG.md,
+# package.json, .release-please-manifest.json). When a previous release PR is
+# squash-merged to main, those same files change on main, making the existing
+# release-please branch stale. The next release-please run may not be able to
+# force-push if GitHub has already marked the PR as conflicted.
+#
+# Calling workflow should trigger on:
+#   push:
+#     branches: [main]
+#   schedule:
+#     - cron: "*/30 * * * *"
+#   workflow_dispatch: {}
+
+on:
+  workflow_call:
+    inputs:
+      release-workflow-file:
+        description: 'Filename of the release-please workflow to retrigger'
+        required: false
+        type: string
+        default: 'release-please.yml'
+    secrets:
+      RELEASE_PLEASE_TOKEN:
+        description: 'PAT with contents:write and pull-requests:write scopes (falls back to GITHUB_TOKEN)'
+        required: false
+
+concurrency:
+  group: fix-release-conflicts-${{ github.repository }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  fix-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for release-please to finish
+        if: github.event_name == 'push'
+        run: sleep 30
+
+      - name: Check for conflicted release-please PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # Find open release-please PRs
+          PR_JSON=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "release-please--branches--main" \
+            --state open \
+            --json number,mergeable,headRefName \
+            --limit 1 \
+            -q '.[0] // empty')
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No open release-please PR found"
+            echo "has_conflict=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
+          BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+
+          echo "PR #$NUMBER on branch $BRANCH — mergeable: $MERGEABLE"
+
+          if [ "$MERGEABLE" = "CONFLICTING" ]; then
+            echo "has_conflict=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$NUMBER" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflict=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close conflicted PR and delete branch
+        if: steps.check.outputs.has_conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.check.outputs.pr_number }}"
+          BRANCH="${{ steps.check.outputs.branch }}"
+
+          echo "Closing conflicted PR #$PR_NUMBER and deleting branch $BRANCH"
+
+          gh pr close "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --comment "Closing due to merge conflicts. Release-please will recreate this PR automatically on the next trigger." \
+            --delete-branch
+
+          echo "Deleted branch $BRANCH"
+
+      - name: Retrigger release-please
+        if: steps.check.outputs.has_conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering ${{ inputs.release-workflow-file }} to recreate the PR"
+          gh workflow run "${{ inputs.release-workflow-file }}" \
+            --repo "${{ github.repository }}" \
+            --ref main
+          echo "Workflow triggered successfully"

--- a/.github/workflows/reusable-renovate.yml
+++ b/.github/workflows/reusable-renovate.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@v46
+      - uses: renovatebot/github-action@v46.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: ${{ inputs.config-file }}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Call these from any FVH repo using `uses: ForumViriumHelsinki/.github/.github/wo
 | `reusable-container-build.yml` | PR phase: build and push `:next-{version}` pre-release image to GHCR |
 | `reusable-container-release.yml` | Release phase: promote pre-built image to semver tags (or fallback rebuild) + Trivy scan |
 | `reusable-release-please.yml` | Automated releases via release-please |
-| `reusable-auto-merge-image-updater.yml` | Auto-merge ArgoCD Image Updater PRs |
+| `reusable-auto-merge-image-updater.yml` | Auto-merge ArgoCD Image Updater PRs (single-job, push-triggered) |
+| `reusable-fix-release-conflicts.yml` | Auto-resolve release-please merge conflicts |
 | `reusable-renovate.yml` | Dependency updates via Renovate |
 | `reusable-claude.yml` | Claude Code @-mention support in issues and PRs |
 
@@ -90,6 +91,31 @@ jobs:
     uses: ForumViriumHelsinki/.github/.github/workflows/reusable-security-owasp.yml@main
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+## Container Signing
+
+Release images are signed with [Sigstore cosign](https://docs.sigstore.dev/) using keyless mode (OIDC identity from GitHub Actions). Signatures are recorded in the [Rekor](https://docs.sigstore.dev/logging/overview/) public transparency log.
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='https://github.com/ForumViriumHelsinki/' \
+  ghcr.io/forumviriumhelsinki/my-app:1.2.3
+```
+
+### Opting out
+
+Pass `enable-signing: false` to the release workflow:
+
+```yaml
+uses: ForumViriumHelsinki/.github/.github/workflows/reusable-container-release.yml@main
+with:
+  image-name: forumviriumhelsinki/my-app
+  tag-prefix: my-app-v
+  enable-signing: false
 ```
 
 ## Community Health Files

--- a/workflow-templates/fvh-app.yml
+++ b/workflow-templates/fvh-app.yml
@@ -2,7 +2,7 @@ name: FVH App CI/CD
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'image-updater-**']
     tags:
       - '*-v*.*.*'
   pull_request:
@@ -38,10 +38,14 @@ jobs:
     secrets:
       RELEASE_PLEASE_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
 
-  # Auto-merge ArgoCD Image Updater PRs
+  # Auto-merge ArgoCD Image Updater PRs.
+  # Single-job design: creates PR, approves, and enables auto-merge in one run
+  # to avoid GITHUB_TOKEN anti-recursion (GITHUB_TOKEN PRs don't fire pull_request events).
   auto-merge:
-    if: github.event_name == 'pull_request'
+    if: startsWith(github.ref_name, 'image-updater-')
     uses: ForumViriumHelsinki/.github/.github/workflows/reusable-auto-merge-image-updater.yml@main
+    with:
+      pr-title: "build: automatic update of ${{ github.event.repository.name }}"
     secrets:
       AUTO_MERGE_PAT: ${{ secrets.AUTO_MERGE_PAT }}
 


### PR DESCRIPTION
## Summary

- **fix(auto-merge)**: Redesign `reusable-auto-merge-image-updater` to single-job push-triggered pattern. The previous two-job design was broken: `GITHUB_TOKEN`-authored PR creation doesn't trigger new `pull_request` workflow runs (GitHub anti-recursion), so the merge job never fired. Single job now creates PR, approves, and enables auto-merge sequentially. Replaces `branch-prefix` input with `pr-title`.
- **feat**: Add `reusable-fix-release-conflicts.yml` — detects conflicted release-please PRs, closes/deletes the stale branch, and retriggers the release workflow.
- **feat(container-release)**: Add cosign keyless signing with `enable-signing` input. Signs by digest using Sigstore keyless mode; step summary includes digest, Rekor link, and verify command.
- **chore**: Bump `actions/checkout@v4` → `@v6` in `reusable-claude`
- **chore**: Bump `renovatebot/github-action@v46` → `@v46.1.0`
- **fix(template)**: Update `fvh-app.yml` starter template for new auto-merge trigger pattern (`push` on `image-updater-**` branches instead of `pull_request`)
- **docs**: Document container signing in README, add new workflow to table

## Breaking change

`reusable-auto-merge-image-updater` callers must update their trigger from `pull_request` to `push: branches: ['image-updater-**']` and update the job condition. The starter template (`fvh-app.yml`) is already updated. Application repos using this reusable will need the same adjustment.

## Test plan

- [ ] Verify YAML syntax is valid for all changed workflows
- [ ] Confirm next ArgoCD Image Updater push creates PR, approves, and auto-merges in one run
- [ ] Confirm `reusable-fix-release-conflicts` triggers correctly on push to main and schedule
- [ ] Confirm cosign signing step runs on next container release

🤖 Generated with [Claude Code](https://claude.com/claude-code)