### PR TITLE
fix(renovate): add RENOVATE_REPOSITORIES and update checkout to v6

### DIFF
--- a/.github/workflows/reusable-renovate.yml
+++ b/.github/workflows/reusable-renovate.yml
@@ -33,7 +33,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: renovatebot/github-action@v46.1.0
         with:
@@ -42,4 +42,5 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.log-level }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run != 'false' && inputs.dry-run || '' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: '[{"matchHost":"ghcr.io","hostType":"docker","username":"x-access-token","password":"${{ secrets.GITHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary
- Add `RENOVATE_REPOSITORIES: ${{ github.repository }}` env var to reusable Renovate workflow — resolves to the caller's repo name in `workflow_call` context
- Update `actions/checkout` from v4 to v6

Without `RENOVATE_REPOSITORIES`, all repos calling this reusable workflow silently log "No repositories found" and do nothing. This is the same fix applied to infrastructure in `df21bc6`.

## Test plan
- [ ] Trigger manual `workflow_dispatch` on an app repo that calls this reusable workflow
- [ ] Verify Renovate logs show "Repository: ForumViriumHelsinki/{repo}" instead of "No repositories found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)