### PR TITLE
fix(workflows): rename release-please secret to match org secret

### DIFF
--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: '.release-please-manifest.json'
     secrets:
-      RELEASE_PLEASE_TOKEN:
+      MY_RELEASE_PLEASE_TOKEN:
         description: 'PAT with contents:write and pull-requests:write scopes'
         required: true
     outputs:
@@ -44,6 +44,6 @@ jobs:
       - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}


### PR DESCRIPTION
## Summary
- Renames `RELEASE_PLEASE_TOKEN` → `MY_RELEASE_PLEASE_TOKEN` in the reusable release-please workflow
- Matches the existing organization secret name
- Pre-requisite for migrating repos to use this reusable workflow

## Test plan
- [ ] Verify `MY_RELEASE_PLEASE_TOKEN` is configured as an org secret
- [ ] After merge, migrate repos to use the reusable workflow caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)