### PR TITLE
fix(workflows): enable file editing and Bash tools in Claude workflow

### DIFF
--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -11,7 +11,7 @@ on:
         type: string
         default: 'ubuntu-slim'
       claude_args:
-        description: 'Additional arguments for Claude Code (appended after default --max-turns and --system-prompt)'
+        description: 'Additional arguments for Claude Code (appended after default --max-turns, --allowedTools, and --system-prompt)'
         type: string
         required: false
         default: ''
@@ -20,6 +20,15 @@ on:
         type: number
         required: false
         default: 50
+      allowed_tools:
+        description: >-
+          Comma-separated list of additional tools to allow beyond the action defaults
+          (Glob, Grep, LS, Read, git commit/push). Passed to --allowedTools.
+          Default covers FVH stack: file editing, Python (uv/pytest/ruff),
+          TypeScript (bun/biome), just task runner, and pre-commit hooks.
+        type: string
+        required: false
+        default: 'Edit,Write,Bash(uv *),Bash(pytest *),Bash(python *),Bash(ruff *),Bash(bun *),Bash(biome *),Bash(node *),Bash(just *),Bash(pre-commit *),Bash(make *)'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -60,6 +69,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --max-turns ${{ inputs.max_turns }}
+            --allowedTools "${{ inputs.allowed_tools }}"
             --system-prompt "You have a limited turn budget of ${{ inputs.max_turns }} turns in CI.
 
             Strategy:


### PR DESCRIPTION
## Summary

- **Fix:** Add `--allowedTools` to the reusable Claude workflow so `@claude` mentions can actually edit files and run build tools — the action's defaults only permit read-only access (`Glob, Grep, LS, Read`) plus git commit/push
- **New input:** `allowed_tools` with FVH-stack defaults: `Edit`, `Write`, and Bash patterns for Python (uv, pytest, ruff), TypeScript (bun, biome), just, pre-commit, and make
- **Error handling** (from prior commit): improved failure detection and continuation instructions when Claude hits max-turns or errors

## Context

Discovered via ForumViriumHelsinki/IDEA-Helsinki#328 — Claude burned 51 turns with 10 permission denials trying to use `Edit`/`Write` tools that weren't allowed, exhausted the turn budget without producing any code, and reported a misleading `Execution file not found` error.

## Test plan

- [ ] Trigger `@claude` on an issue requesting a code change — verify Claude can now create/edit files and commit
- [ ] Verify existing callers (IDEA-Helsinki, etc.) work without changes (new input has a default)
- [ ] Optionally test overriding `allowed_tools` from a caller workflow to verify customization works

Fixes ForumViriumHelsinki/IDEA-Helsinki#328

🤖 Generated with [Claude Code](https://claude.com/claude-code)