### PR TITLE
fix(container-release): parse digest from imagetools inspect text output

### DIFF
--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -184,7 +184,16 @@ jobs:
         id: release-digest
         run: |
           FIRST_TAG=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)
-          DIGEST=$(docker buildx imagetools inspect "${FIRST_TAG}" --format '{{.Manifest.Digest}}')
+          # Extract the top-level digest from imagetools inspect text output.
+          # --format '{{.Manifest.Digest}}' fails for OCI index/manifest list
+          # types (no .Digest field), producing multi-line output that breaks
+          # $GITHUB_OUTPUT parsing. The text output has a top-level
+          # "Digest: sha256:..." line (unindented, unlike sub-manifest lines).
+          DIGEST=$(docker buildx imagetools inspect "${FIRST_TAG}" | grep -m1 '^Digest:' | awk '{print $2}')
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::Failed to extract digest from imagetools inspect output"
+            exit 1
+          fi
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "image=ghcr.io/${{ inputs.image-name }}@${DIGEST}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

Fix the "Capture release image digest" step that fails with `Invalid format 'MediaType: ...'` when writing to `$GITHUB_OUTPUT`. This blocked cosign signing and Trivy scanning on every container release.

## Changes

- Replace `--format '{{.Manifest.Digest}}'` with text output parsing (`grep '^Digest:' | awk '{print $2}'`)
- Add explicit error guard if digest extraction fails

**Root cause:** `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` fails for OCI index/manifest list types (used even for single-platform images built with provenance/SBOM attestations). The `.Manifest.Digest` field doesn't exist on index types — the digest is computed externally by hashing the manifest content. This caused the full multi-line inspect output to be captured, and the `MediaType:` line broke `$GITHUB_OUTPUT`'s `key=value` format.

## Testing

- [ ] actionlint passes (no new issues — pre-existing shellcheck info warnings only)
- [ ] Trigger a container release in a test repo to verify digest is correctly extracted
- [ ] Verify cosign signing and Trivy scan execute after the fix

## Related

Closes #30