### PR TITLE
feat(workflows): add secret-build-args passthrough to reusable container workflows

### DIFF
--- a/.github/workflows/reusable-container-build.yml
+++ b/.github/workflows/reusable-container-build.yml
@@ -49,6 +49,15 @@ on:
         required: false
         type: string
         default: "jq -r '.version' package.json"
+    secrets:
+      secret-build-args:
+        description: |
+          Additional newline-separated KEY=VALUE Docker build arguments whose values are secrets.
+          Use for tokens that must reach the build but should not appear in the `build-args` input.
+          Values are masked in logs. The caller typically populates this with secrets from its
+          own repository, e.g. passing a Sentry auth token or an NPM registry token. See the
+          caller-side documentation for usage examples.
+        required: false
     outputs:
       pre-release-tag:
         description: 'The full pre-release image reference pushed (ghcr.io/…:next-{version})'
@@ -112,6 +121,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}
             ${{ inputs.build-args }}
+            ${{ secrets.secret-build-args }}
           cache-from: type=gha,scope=${{ inputs.cache-scope }}
           cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
           # SBOM and provenance deferred to the release/promote job

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -56,6 +56,14 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      secret-build-args:
+        description: |
+          Additional newline-separated KEY=VALUE Docker build arguments whose values are secrets.
+          Used only by the fallback rebuild path — ignored on the fast-path promotion, which
+          inherits the layers built by reusable-container-build.yml. Pass the same secrets as
+          the PR-phase caller so the fallback rebuild produces an equivalent image.
+        required: false
     outputs:
       version:
         description: 'Released version'
@@ -169,6 +177,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}
             ${{ inputs.build-args }}
+            ${{ secrets.secret-build-args }}
           cache-from: type=gha,scope=${{ inputs.cache-scope }}
           cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
           provenance: mode=max


### PR DESCRIPTION
## Summary

Adds an optional `secret-build-args` secret input to both `reusable-container-build.yml` and `reusable-container-release.yml` so caller repos can inject secret `KEY=VALUE` Docker build arguments (e.g. `SENTRY_AUTH_TOKEN`, private registry tokens) without leaking them through the plain `inputs.build-args` string.

## Why

GitHub Actions does not allow the `secrets` context inside a reusable workflow caller's `with:` block — secrets must flow through a declared `secrets:` input on the called workflow. The existing reusable container workflows only expose `inputs.build-args` (plain string), so any caller whose build needs a secret build-arg is forced to keep an inline container-build.yml.

Immediate motivating case: **R4C-Cesium-Viewer**, whose current inline container-build.yml passes `SENTRY_AUTH_TOKEN` and `VITE_SENTRY_DSN` as build-args for source-map upload and client-bundle DSN injection. Its tag-triggered builds have been failing since 2026-03-30 (the `reproducible-containers/buildkit-cache-dance` step throws EACCES on \`/root/.bun/install/cache\`), so the `1.46.0` and `1.47.0` container images never actually made it to GHCR. Migrating that repo to these reusable workflows drops the broken cache-dance step and adopts build-once/promote — but requires this secret passthrough first.

## Changes

- `reusable-container-build.yml`: declare `secrets.secret-build-args` (optional), append its value into the `build-args` block of the Build and push pre-release image step
- `reusable-container-release.yml`: same declaration and append on the fallback rebuild path (the fast-path promotion inherits layers from the PR-phase image and ignores build-args entirely — noted in the description)

## Design notes

- Generic KEY=VALUE passthrough rather than named tokens (`SENTRY_AUTH_TOKEN`, etc.) — one change supports any current and future caller without amending the shared workflow per secret
- Secret values are masked in logs by GHA's default masking wherever they appear, including in the expanded build-args argument
- Release-phase promotion does not rebuild, so `secret-build-args` is only consumed by the fallback rebuild; callers should pass the same secrets to build- and release-phase callers for consistency if the fallback is ever exercised

## Testing

- [x] `actionlint` clean on both files (no new errors; pre-existing SC2086 warnings on unrelated run-blocks are unchanged)
- [ ] End-to-end validation via the R4C-Cesium-Viewer migration PR (will be opened against this SHA once merged)

## Related

- Motivating migration: ForumViriumHelsinki/R4C-Cesium-Viewer (migration PR to follow once this merges)
- Background on the R4C build breakage: ForumViriumHelsinki/R4C-Cesium-Viewer#699