### PR TITLE
feat(claude): enroll laurigates/claude-plugins marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pre-commit:*)",
+      "Bash(gitleaks:*)",
+      "Bash(python3:*)",
+      "Bash(actionlint:*)",
+      "Bash(npx rulesync:*)",
+      "mcp__github"
+    ],
     "deny": [
       "Read(.rulesync/)",
       "Read(node_modules/)",
@@ -7,5 +17,20 @@
       "Read(rulesync.local.jsonc)",
       "Read(rulesync.lock)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins": {
+      "source": { "source": "github", "repo": "laurigates/claude-plugins" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "configure-plugin@claude-plugins": true,
+    "health-plugin@claude-plugins": true,
+    "hooks-plugin@claude-plugins": true,
+    "github-actions-plugin@claude-plugins": true,
+    "git-plugin@claude-plugins": true,
+    "code-quality-plugin@claude-plugins": true,
+    "tools-plugin@claude-plugins": true
   }
 }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,17 @@ jobs:
           additional_permissions: |
             actions: read
 
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            configure-plugin@laurigates-claude-plugins
+            health-plugin@laurigates-claude-plugins
+            hooks-plugin@laurigates-claude-plugins
+            github-actions-plugin@laurigates-claude-plugins
+            git-plugin@laurigates-claude-plugins
+            code-quality-plugin@laurigates-claude-plugins
+            tools-plugin@laurigates-claude-plugins
+
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 


### PR DESCRIPTION
## Summary

- Enrolls the [`laurigates/claude-plugins`](https://github.com/laurigates/claude-plugins) marketplace in `.claude/settings.json` (`extraKnownMarketplaces`) so local + ephemeral web sessions both have plugin access.
- Adds matching `plugin_marketplaces` + `plugins` inputs to `.github/workflows/claude.yml` so `@claude` runs on this repo load the same plugin set.
- Enables seven plugins relevant to a workflow/rules hub: `configure-plugin`, `health-plugin`, `hooks-plugin`, `github-actions-plugin`, `git-plugin`, `code-quality-plugin`, `tools-plugin`.
- Seeds `permissions.allow` with the baseline tools used here (`git`, `gh`, `pre-commit`, `gitleaks`, `python3`, `actionlint`, `npx rulesync`) plus `mcp__github` for issue/PR/release operations. Existing `rulesync` `deny` block preserved.

## Notes

- `claude.yml` keeps its custom `pull_request_review` trigger and `actions: read` permission — only the two new inputs were appended.
- `claude-code-review.yml` was intentionally not added (the hub repo doesn't auto-review its own PRs).
- Requires no new secrets; `CLAUDE_CODE_OAUTH_TOKEN` already exists.

## Test plan

- [ ] Merge and verify next `@claude` mention loads plugins (check workflow logs for marketplace fetch)
- [ ] Open a local Claude Code session in this repo and confirm plugin commands are available