### PR TITLE
feat(release-please): add App-token auth, runner, timeout, skip-on-release-commit inputs

### DIFF
--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -13,10 +13,33 @@ on:
         required: false
         type: string
         default: '.release-please-manifest.json'
+      app-id:
+        description: 'GitHub App ID. When set, uses an App token (via APP_PRIVATE_KEY) instead of MY_RELEASE_PLEASE_TOKEN.'
+        required: false
+        type: string
+        default: ''
+      runner:
+        description: 'Runner label'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 15
+      skip-on-release-commit:
+        description: 'Skip the job when the head commit message starts with "chore(main): release" to prevent cascading releases.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       MY_RELEASE_PLEASE_TOKEN:
-        description: 'PAT with contents:write and pull-requests:write scopes'
-        required: true
+        description: 'PAT with contents:write and pull-requests:write scopes. Required when app-id is empty.'
+        required: false
+      APP_PRIVATE_KEY:
+        description: 'GitHub App private key. Required when app-id is set.'
+        required: false
     outputs:
       release_created:
         description: 'Whether a release was created'
@@ -36,14 +59,27 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    # Skip release-please's own merge commits when skip-on-release-commit is true.
+    if: >-
+      inputs.skip-on-release-commit != true ||
+      !startsWith(github.event.head_commit.message, 'chore(main): release')
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: inputs.app-id != ''
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          token: ${{ inputs.app-id != '' && steps.app-token.outputs.token || secrets.MY_RELEASE_PLEASE_TOKEN }}
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}


### PR DESCRIPTION
Closes #40

## Summary

Extends `reusable-release-please.yml` with four new inputs and one new secret so the infrastructure repo (and any future App-token caller) can migrate without losing features.

| Input | Type | Default | Purpose |
|---|---|---|---|
| `app-id` | string | `''` | GitHub App ID. When set, generates an App token via `actions/create-github-app-token` and uses it instead of `MY_RELEASE_PLEASE_TOKEN`. |
| `runner` | string | `ubuntu-latest` | Runner label (infra uses `ubuntu-slim`). |
| `timeout-minutes` | number | `15` | Job timeout. |
| `skip-on-release-commit` | boolean | `false` | When `true`, skips the job if the head commit message starts with `chore(main): release` to prevent cascading releases. |

| Secret | Required | Purpose |
|---|---|---|
| `APP_PRIVATE_KEY` | no | GitHub App private key (required iff `app-id` is set). |

`MY_RELEASE_PLEASE_TOKEN` is now optional. Existing PAT callers continue to work unchanged (app-id defaults to empty).

## Behavior

- When `app-id` is empty: uses `secrets.MY_RELEASE_PLEASE_TOKEN` directly (existing behavior).
- When `app-id` is set: generates an App token with `actions/create-github-app-token@1b10c78…` (v3.1.1 pinned) and passes it to `release-please-action` as `token:`.
- `skip-on-release-commit: true` short-circuits the job with no-op behavior (job skipped via `if:` guard).

## Follow-ups

- `.rulesync/rules/ci-cd-workflows.md` source should document the new inputs — will be added in a follow-up commit on this branch (permission-gated locally).
- After merge, migrate `infrastructure/.github/workflows/release-please.yaml` to call this reusable workflow (#23).

## Test plan

- [ ] actionlint passes (validated locally)
- [ ] Test via workflow_dispatch in a test repo with `app-id` + `APP_PRIVATE_KEY` set
- [ ] Verify existing PAT callers (ApplicationEvaluator, google-chat-agent) continue to work — they don't set `app-id`, so code path is unchanged
- [ ] Verify `skip-on-release-commit: true` correctly skips on `chore(main): release ...` head commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)