### PR TITLE
feat(renovate): add App-token auth and bot-identity inputs

### DIFF
--- a/.github/workflows/reusable-renovate.yml
+++ b/.github/workflows/reusable-renovate.yml
@@ -18,6 +18,30 @@ on:
         required: false
         type: string
         default: 'false'
+      app-id:
+        description: 'Renovate GitHub App ID. When set, generates an App token (via APP_PRIVATE_KEY) instead of using GITHUB_TOKEN.'
+        required: false
+        type: string
+        default: ''
+      bot-username:
+        description: 'RENOVATE_USERNAME (e.g. fvh-renovate-bot[bot]). Only applies when app-id is set.'
+        required: false
+        type: string
+        default: ''
+      bot-git-author:
+        description: 'RENOVATE_GIT_AUTHOR full author string (e.g. "bot <bot[bot]@users.noreply.github.com>"). Only applies when app-id is set.'
+        required: false
+        type: string
+        default: ''
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 60
+    secrets:
+      APP_PRIVATE_KEY:
+        description: 'Renovate App private key. Required iff app-id is set.'
+        required: false
 
 concurrency:
   group: renovate-${{ github.repository }}
@@ -32,15 +56,27 @@ permissions:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: inputs.app-id != ''
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
 
       - uses: renovatebot/github-action@v46.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ inputs.app-id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           configurationFile: ${{ inputs.config-file }}
         env:
           LOG_LEVEL: ${{ inputs.log-level }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run != 'false' && inputs.dry-run || '' }}
+          RENOVATE_USERNAME: ${{ inputs.bot-username }}
+          RENOVATE_GIT_AUTHOR: ${{ inputs.bot-git-author }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_HOST_RULES: '[{"matchHost":"ghcr.io","hostType":"docker","username":"x-access-token","password":"${{ secrets.GITHUB_TOKEN }}"}]'
+          RENOVATE_HOST_RULES: "[{\"matchHost\":\"ghcr.io\",\"hostType\":\"docker\",\"username\":\"x-access-token\",\"password\":\"${{ inputs.app-id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}\"}]"


### PR DESCRIPTION
Closes #41

## Summary

Extends `reusable-renovate.yml` with four new inputs and one new secret so the infrastructure repo (and any future App-authenticated caller) can migrate without losing its bot identity.

| Input | Type | Default | Purpose |
|---|---|---|---|
| `app-id` | string | `''` | Renovate GitHub App ID. When set, generates an App token via `actions/create-github-app-token` instead of using `GITHUB_TOKEN`. |
| `bot-username` | string | `''` | `RENOVATE_USERNAME` (e.g. `fvh-renovate-bot[bot]`) for bot commit authorship. |
| `bot-git-author` | string | `''` | `RENOVATE_GIT_AUTHOR` full author string. |
| `timeout-minutes` | number | `60` | Job timeout. |

| Secret | Required | Purpose |
|---|---|---|
| `APP_PRIVATE_KEY` | no | Renovate App private key (required iff `app-id` is set). |

## Behavior

- When `app-id` is empty: uses `secrets.GITHUB_TOKEN` directly (existing behavior).
- When `app-id` is set: generates an App token with `actions/create-github-app-token@1b10c78…` (v3.1.1 pinned) and passes it to `renovatebot/github-action` as `token:`. The token is also injected into `RENOVATE_HOST_RULES` for GHCR docker auth, matching infrastructure's current workflow.
- `RENOVATE_USERNAME` and `RENOVATE_GIT_AUTHOR` only take effect when set via the inputs (empty by default).

## Implementation notes

- `RENOVATE_HOST_RULES` switched to double-quoted YAML to avoid conflicts between YAML single-quote escaping (`''`) and the GitHub Actions expression empty-string literal (`''`) — actionlint rejected the single-quoted form.

## Follow-ups

- `.rulesync/rules/ci-cd-workflows.md` source should document the new inputs — permission-gated locally, will be added separately.
- After merge (along with #42), migrate `infrastructure/.github/workflows/renovate.yml` to call this reusable workflow (#23).

## Test plan

- [ ] actionlint passes (validated locally)
- [ ] Test via workflow_dispatch in a test repo with `app-id` + `bot-username` + `bot-git-author` set
- [ ] Verify existing `GITHUB_TOKEN` callers continue to work — they don't set `app-id`, so code path is unchanged
- [ ] Confirm Renovate PRs on test repo are authored by the configured bot identity when App mode is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)