### PR TITLE
fix(ci): run gh pr merge outside checkout to fix --delete-branch

### DIFF
--- a/.github/workflows/reusable-auto-merge-image-updater.yml
+++ b/.github/workflows/reusable-auto-merge-image-updater.yml
@@ -67,6 +67,11 @@ jobs:
         run: gh pr review --approve "${{ github.ref_name }}"
 
       - name: Enable auto-merge
+        # Run outside the checkout so gh skips local-clone cleanup. With
+        # --delete-branch, gh otherwise tries `git checkout -B main origin/main`,
+        # which fails in a fetch-depth=1 checkout that only has the PR branch.
+        working-directory: ${{ runner.temp }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh pr merge --auto --delete-branch --${{ inputs.merge-method }} "${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

- Make `Enable auto-merge` step run from `${{ runner.temp }}` with `GH_REPO` set so `gh pr merge` skips local-clone cleanup.
- Fixes the regression introduced in 85b7bcc (#26) when `--delete-branch` was added.

## Background

After 85b7bcc, runs of \`reusable-auto-merge-image-updater.yml\` started failing in caller workflows (e.g. \`theme-management\` 1.75.0, 1.76.0, 1.76.1, 1.77.1) at the \`Enable auto-merge\` step:

\`\`\`
failed to run git: fatal: 'origin/main' is not a commit and a branch 'main' cannot be created from it
\`\`\`

The auto-merge itself was succeeding (PRs merged at the same second as the failure), but \`gh pr merge --delete-branch\` performs **local-clone** cleanup as well — it runs \`git checkout -B main origin/main\` after the API call. The \`actions/checkout@v6\` step uses the default \`fetch-depth: 1\` and only fetches the PR branch, so \`origin/main\` does not exist locally and the cleanup fails with a non-zero exit, marking the whole workflow failed.

## Fix

Run the step from \`\${{ runner.temp }}\` (outside any git work tree) with \`GH_REPO\` set. This makes \`gh\` treat it as a pure GitHub API call and skip local cleanup entirely. Smallest possible change — leaves the existing \`actions/checkout@v6\` for the earlier steps untouched.

## Evidence

Failing run on \`theme-management\`: https://github.com/ForumViriumHelsinki/theme-management/actions/runs/24993026457 (PR #1034 merged at 11:44:01, step failed at 11:44:02 with the git error above).

## Test plan

- [ ] Merge this PR.
- [ ] Wait for the next argocd-image-updater push to any caller repo (or trigger one manually).
- [ ] Confirm the \`Enable auto-merge\` step exits 0 and the workflow run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)