### PR TITLE
feat(reusable-claude): allow GitHub MCP issue tools by default

### DIFF
--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -25,10 +25,13 @@ on:
           Comma-separated list of additional tools to allow beyond the action defaults
           (Glob, Grep, LS, Read, git commit/push). Passed to --allowedTools.
           Default covers FVH stack: file editing, Python (uv/pytest/ruff),
-          TypeScript (bun/biome), just task runner, and pre-commit hooks.
+          TypeScript (bun/biome), just task runner, pre-commit hooks, and
+          GitHub MCP server tools for issue management (mcp__github__*).
+          Listing any mcp__github__* tool causes the action to mount
+          ghcr.io/github/github-mcp-server automatically.
         type: string
         required: false
-        default: 'Edit,Write,Bash(uv *),Bash(pytest *),Bash(python *),Bash(ruff *),Bash(bun *),Bash(biome *),Bash(node *),Bash(just *),Bash(pre-commit *),Bash(make *)'
+        default: 'Edit,Write,Bash(uv *),Bash(pytest *),Bash(python *),Bash(ruff *),Bash(bun *),Bash(biome *),Bash(node *),Bash(just *),Bash(pre-commit *),Bash(make *),mcp__github__get_issue,mcp__github__list_issues,mcp__github__list_issue_types,mcp__github__search_issues,mcp__github__create_issue,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__get_issue_comments,mcp__github__add_sub_issue,mcp__github__list_sub_issues'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true


### PR DESCRIPTION
## Summary

Adds ten `mcp__github__*` issue-management tools to `reusable-claude.yml`'s default `allowed_tools` list so that `@claude` mentions can actually create / update / link GitHub issues.

## Why

Currently Claude can read code, edit files, run a fixed set of bash commands, and update its own status comment — but it has no way to call the GitHub Issues API. Asking Claude to "open a follow-up issue" silently 6×-denies and exits with `subtype: success`, leaving a stale checklist on the PR.

Concrete failure: [ForumViriumHelsinki/infrastructure#1770 comment](https://github.com/ForumViriumHelsinki/infrastructure/pull/1770#issuecomment-4376877149) — Claude was asked to file a Terraform-import follow-up, ran for 2m50s, hit `permission_denials_count: 6`, posted nothing useful, and the workflow concluded green because the SDK call itself returned cleanly.

## How

The `claude-code-action` already ships `ghcr.io/github/github-mcp-server:sha-23fa0dd` (= v0.17.1) as a Docker MCP server, and lazily mounts it whenever any `mcp__github__*` name appears in the allowlist (see [`src/mcp/install-mcp-server.ts:76-78,206-224`](https://github.com/anthropics/claude-code-action/blob/v1/src/mcp/install-mcp-server.ts)). Token plumbing (`GITHUB_PERSONAL_ACCESS_TOKEN`) is wired automatically from the workflow's `GITHUB_TOKEN`. So this PR is purely an allowlist edit — no `mcp_config:` JSON, no Docker dependency change, no secret plumbing.

Tools added (read / scoped-write only, no `merge_pull_request`, `delete_*`, `fork_*`, etc.):

| Tool | Purpose |
|---|---|
| `get_issue`, `list_issues`, `list_issue_types`, `search_issues` | Read + duplicate-check before creating (per `github-metadata-hygiene.md`) |
| `create_issue`, `update_issue` | File new + close / edit metadata |
| `add_issue_comment`, `get_issue_comments` | Comment + read thread |
| `add_sub_issue`, `list_sub_issues` | Manage sub-issue / dependency relationships |

## Out of scope

PR-review tools (`get_pull_request_diff`, `create_pending_pull_request_review`, `add_comment_to_pending_review`, `submit_pending_pull_request_review`, …) are deliberately not in this PR — they belong with `reusable-claude-review.yml`'s allowlist work and have a different review-and-rollout shape.

Also out of scope: surfacing `permission_denials_count > 0` as a workflow annotation. That's a separate observability concern — without it, future allowlist gaps will keep looking like "successful" runs. Worth a follow-up issue once this lands.

## Test plan

- [ ] On merge, monitor the next `@claude` mention that asks for an issue creation in any FVH repo — first cold run will pull the Docker image (~5–10 s).
- [ ] Verify a follow-up issue can be created from a PR comment (e.g. re-run the failing case from infrastructure#1770).
- [ ] Confirm `permission_denials_count` for issue-related operations drops to 0 in the execution-output JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)