### PR TITLE
chore(rulesync): regenerate stale tool outputs

### DIFF
--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -1,0 +1,83 @@
+---
+paths:
+  - '**/*'
+---
+# GitHub Metadata Hygiene
+
+## Rule: Every issue and PR must have complete metadata — enforce on every GitHub interaction
+
+### Trigger Points
+
+Apply these checks when:
+1. **Creating** issues or PRs — set all metadata at creation time
+2. **Commenting or reviewing** existing issues/PRs — check for gaps and backfill
+3. **Before opening a PR** — verify the target issue has proper metadata
+
+### Issue Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
+| Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
+| Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
+| Linked PR | When applicable | PR body `Closes #N` or `gh issue develop` | Link when creating PRs that address the issue |
+
+### PR Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
+| Project | Always | `-p <title>` | Same project as linked issue |
+| Linked issue | Always | PR body with `Closes #N` / `Fixes #N` | Reference the issue being addressed |
+
+**Self-review guard:** Before requesting a reviewer, check the PR author. If the requested reviewer matches the PR author, skip the `--add-reviewer` / `-r` flag entirely. Use separate `gh` commands for reviewer vs. other metadata to avoid a single 422 failing the entire update.
+
+### Project Determination
+
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+
+| # | Project | Label | Context Signals |
+|---|---------|-------|----------------|
+| 1 | ICT | `project:ict` | General infrastructure, IT operations, cross-cutting concerns |
+| 2 | Reusable Workflow Migration | `project:reusable-workflows` | CI/CD workflows, `.github/workflows/`, reusable workflow adoption |
+| 3 | Template: Epic | — | Epic-level planning and tracking |
+| 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
+| 5 | TFDS | `project:tfds` | TFDS application and related services |
+| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
+| 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
+| 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
+| 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+
+If context doesn't clearly map to one project, ask the user before proceeding.
+
+### Backfill on Existing Issues/PRs
+
+When interacting with an issue or PR that has missing metadata:
+
+1. Add missing assignee (`laurigates`) and reviewer (`laurigates` for PRs — skip if author matches reviewer)
+2. Add missing type labels — infer from title and content
+3. Add to the appropriate project if not yet linked
+4. Inform the user what was added (do not silently modify)
+
+### Label Conventions
+
+Use these standard type labels consistently:
+
+| Label | When |
+|-------|------|
+| `bug` | Defect or broken behavior |
+| `enhancement` | New feature or improvement to existing feature |
+| `chore` | Maintenance, dependency updates, refactoring |
+| `docs` | Documentation changes |
+| `security` | Security-related fixes or improvements |
+
+Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.
+
+**No `triage` label.** The org does not currently define a `triage` label in `infrastructure/github/labels.tf`. For investigation-stage issues where the root cause is not yet confirmed, use the `bug` label with a `triage(scope): ...` conventional-commit title prefix to signal the diagnostic intent. Do not request a `triage` label be added without first confirming the workflow needs one — the title prefix has been sufficient in practice.
+
+**Labels are Terraform-managed.** Org-wide labels are defined in `infrastructure/github/labels.tf` (`local.standard_labels`). Do not create labels via `gh label create` — they will be destroyed on the next Terraform apply. To add a new label, add it to `labels.tf` and apply via Terraform Cloud (`infrastructure-github` workspace).

--- a/.claude/rules/local-development.md
+++ b/.claude/rules/local-development.md
@@ -55,3 +55,21 @@ Install and run:
 pre-commit install
 pre-commit run --all-files
 ```
+
+## Local ↔ CI Parity
+
+**Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
+
+Concrete patterns that help:
+
+- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
+- When CI adds a new check, update the matching local recipe in the same PR.
+
+**Known-acceptable deviations:** full parity isn't always feasible — heavy Playwright suites, integration tests requiring external services, or long-running security scans may be CI-only. When diverging intentionally:
+
+- Note it in the recipe comment or the job, so the next person understands the gap
+- Prefer a lighter local variant (e.g. `just test-unit` locally, full suite in CI) over nothing
+- Track "fix properly" work as an issue when the divergence is a temporary workaround (e.g. runner capacity), not a permanent design choice
+
+Don't enforce parity strictly during reviews — surface the gap, suggest a lighter local equivalent, and move on.

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -1,0 +1,84 @@
+---
+description: GitHub issue and PR metadata standards — assignee, labels, project routing, label hygiene
+globs: **/*
+---
+
+# GitHub Metadata Hygiene
+
+## Rule: Every issue and PR must have complete metadata — enforce on every GitHub interaction
+
+### Trigger Points
+
+Apply these checks when:
+1. **Creating** issues or PRs — set all metadata at creation time
+2. **Commenting or reviewing** existing issues/PRs — check for gaps and backfill
+3. **Before opening a PR** — verify the target issue has proper metadata
+
+### Issue Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
+| Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
+| Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
+| Linked PR | When applicable | PR body `Closes #N` or `gh issue develop` | Link when creating PRs that address the issue |
+
+### PR Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
+| Project | Always | `-p <title>` | Same project as linked issue |
+| Linked issue | Always | PR body with `Closes #N` / `Fixes #N` | Reference the issue being addressed |
+
+**Self-review guard:** Before requesting a reviewer, check the PR author. If the requested reviewer matches the PR author, skip the `--add-reviewer` / `-r` flag entirely. Use separate `gh` commands for reviewer vs. other metadata to avoid a single 422 failing the entire update.
+
+### Project Determination
+
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+
+| # | Project | Label | Context Signals |
+|---|---------|-------|----------------|
+| 1 | ICT | `project:ict` | General infrastructure, IT operations, cross-cutting concerns |
+| 2 | Reusable Workflow Migration | `project:reusable-workflows` | CI/CD workflows, `.github/workflows/`, reusable workflow adoption |
+| 3 | Template: Epic | — | Epic-level planning and tracking |
+| 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
+| 5 | TFDS | `project:tfds` | TFDS application and related services |
+| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
+| 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
+| 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
+| 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+
+If context doesn't clearly map to one project, ask the user before proceeding.
+
+### Backfill on Existing Issues/PRs
+
+When interacting with an issue or PR that has missing metadata:
+
+1. Add missing assignee (`laurigates`) and reviewer (`laurigates` for PRs — skip if author matches reviewer)
+2. Add missing type labels — infer from title and content
+3. Add to the appropriate project if not yet linked
+4. Inform the user what was added (do not silently modify)
+
+### Label Conventions
+
+Use these standard type labels consistently:
+
+| Label | When |
+|-------|------|
+| `bug` | Defect or broken behavior |
+| `enhancement` | New feature or improvement to existing feature |
+| `chore` | Maintenance, dependency updates, refactoring |
+| `docs` | Documentation changes |
+| `security` | Security-related fixes or improvements |
+
+Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.
+
+**No `triage` label.** The org does not currently define a `triage` label in `infrastructure/github/labels.tf`. For investigation-stage issues where the root cause is not yet confirmed, use the `bug` label with a `triage(scope): ...` conventional-commit title prefix to signal the diagnostic intent. Do not request a `triage` label be added without first confirming the workflow needs one — the title prefix has been sufficient in practice.
+
+**Labels are Terraform-managed.** Org-wide labels are defined in `infrastructure/github/labels.tf` (`local.standard_labels`). Do not create labels via `gh label create` — they will be destroyed on the next Terraform apply. To add a new label, add it to `labels.tf` and apply via Terraform Cloud (`infrastructure-github` workspace).

--- a/.cursor/rules/local-development.mdc
+++ b/.cursor/rules/local-development.mdc
@@ -53,3 +53,21 @@ Install and run:
 pre-commit install
 pre-commit run --all-files
 ```
+
+## Local ↔ CI Parity
+
+**Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
+
+Concrete patterns that help:
+
+- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
+- When CI adds a new check, update the matching local recipe in the same PR.
+
+**Known-acceptable deviations:** full parity isn't always feasible — heavy Playwright suites, integration tests requiring external services, or long-running security scans may be CI-only. When diverging intentionally:
+
+- Note it in the recipe comment or the job, so the next person understands the gap
+- Prefer a lighter local variant (e.g. `just test-unit` locally, full suite in CI) over nothing
+- Track "fix properly" work as an issue when the divergence is a temporary workaround (e.g. runner capacity), not a permanent design choice
+
+Don't enforce parity strictly during reviews — surface the gap, suggest a lighter local equivalent, and move on.

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -1,0 +1,79 @@
+# GitHub Metadata Hygiene
+
+## Rule: Every issue and PR must have complete metadata — enforce on every GitHub interaction
+
+### Trigger Points
+
+Apply these checks when:
+1. **Creating** issues or PRs — set all metadata at creation time
+2. **Commenting or reviewing** existing issues/PRs — check for gaps and backfill
+3. **Before opening a PR** — verify the target issue has proper metadata
+
+### Issue Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
+| Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
+| Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
+| Linked PR | When applicable | PR body `Closes #N` or `gh issue develop` | Link when creating PRs that address the issue |
+
+### PR Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
+| Project | Always | `-p <title>` | Same project as linked issue |
+| Linked issue | Always | PR body with `Closes #N` / `Fixes #N` | Reference the issue being addressed |
+
+**Self-review guard:** Before requesting a reviewer, check the PR author. If the requested reviewer matches the PR author, skip the `--add-reviewer` / `-r` flag entirely. Use separate `gh` commands for reviewer vs. other metadata to avoid a single 422 failing the entire update.
+
+### Project Determination
+
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+
+| # | Project | Label | Context Signals |
+|---|---------|-------|----------------|
+| 1 | ICT | `project:ict` | General infrastructure, IT operations, cross-cutting concerns |
+| 2 | Reusable Workflow Migration | `project:reusable-workflows` | CI/CD workflows, `.github/workflows/`, reusable workflow adoption |
+| 3 | Template: Epic | — | Epic-level planning and tracking |
+| 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
+| 5 | TFDS | `project:tfds` | TFDS application and related services |
+| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
+| 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
+| 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
+| 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+
+If context doesn't clearly map to one project, ask the user before proceeding.
+
+### Backfill on Existing Issues/PRs
+
+When interacting with an issue or PR that has missing metadata:
+
+1. Add missing assignee (`laurigates`) and reviewer (`laurigates` for PRs — skip if author matches reviewer)
+2. Add missing type labels — infer from title and content
+3. Add to the appropriate project if not yet linked
+4. Inform the user what was added (do not silently modify)
+
+### Label Conventions
+
+Use these standard type labels consistently:
+
+| Label | When |
+|-------|------|
+| `bug` | Defect or broken behavior |
+| `enhancement` | New feature or improvement to existing feature |
+| `chore` | Maintenance, dependency updates, refactoring |
+| `docs` | Documentation changes |
+| `security` | Security-related fixes or improvements |
+
+Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.
+
+**No `triage` label.** The org does not currently define a `triage` label in `infrastructure/github/labels.tf`. For investigation-stage issues where the root cause is not yet confirmed, use the `bug` label with a `triage(scope): ...` conventional-commit title prefix to signal the diagnostic intent. Do not request a `triage` label be added without first confirming the workflow needs one — the title prefix has been sufficient in practice.
+
+**Labels are Terraform-managed.** Org-wide labels are defined in `infrastructure/github/labels.tf` (`local.standard_labels`). Do not create labels via `gh label create` — they will be destroyed on the next Terraform apply. To add a new label, add it to `labels.tf` and apply via Terraform Cloud (`infrastructure-github` workspace).

--- a/.gemini/memories/local-development.md
+++ b/.gemini/memories/local-development.md
@@ -48,3 +48,21 @@ Install and run:
 pre-commit install
 pre-commit run --all-files
 ```
+
+## Local ↔ CI Parity
+
+**Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
+
+Concrete patterns that help:
+
+- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
+- When CI adds a new check, update the matching local recipe in the same PR.
+
+**Known-acceptable deviations:** full parity isn't always feasible — heavy Playwright suites, integration tests requiring external services, or long-running security scans may be CI-only. When diverging intentionally:
+
+- Note it in the recipe comment or the job, so the next person understands the gap
+- Prefer a lighter local variant (e.g. `just test-unit` locally, full suite in CI) over nothing
+- Track "fix properly" work as an issue when the divergence is a temporary workaround (e.g. runner capacity), not a permanent design choice
+
+Don't enforce parity strictly during reviews — surface the gap, suggest a lighter local equivalent, and move on.

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -1,0 +1,85 @@
+---
+description: >-
+  GitHub issue and PR metadata standards — assignee, labels, project routing,
+  label hygiene
+applyTo: '**/*'
+---
+# GitHub Metadata Hygiene
+
+## Rule: Every issue and PR must have complete metadata — enforce on every GitHub interaction
+
+### Trigger Points
+
+Apply these checks when:
+1. **Creating** issues or PRs — set all metadata at creation time
+2. **Commenting or reviewing** existing issues/PRs — check for gaps and backfill
+3. **Before opening a PR** — verify the target issue has proper metadata
+
+### Issue Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
+| Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
+| Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
+| Linked PR | When applicable | PR body `Closes #N` or `gh issue develop` | Link when creating PRs that address the issue |
+
+### PR Metadata Checklist
+
+| Field | Required | How to Set | Default |
+|-------|----------|-----------|---------|
+| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
+| Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
+| Project | Always | `-p <title>` | Same project as linked issue |
+| Linked issue | Always | PR body with `Closes #N` / `Fixes #N` | Reference the issue being addressed |
+
+**Self-review guard:** Before requesting a reviewer, check the PR author. If the requested reviewer matches the PR author, skip the `--add-reviewer` / `-r` flag entirely. Use separate `gh` commands for reviewer vs. other metadata to avoid a single 422 failing the entire update.
+
+### Project Determination
+
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+
+| # | Project | Label | Context Signals |
+|---|---------|-------|----------------|
+| 1 | ICT | `project:ict` | General infrastructure, IT operations, cross-cutting concerns |
+| 2 | Reusable Workflow Migration | `project:reusable-workflows` | CI/CD workflows, `.github/workflows/`, reusable workflow adoption |
+| 3 | Template: Epic | — | Epic-level planning and tracking |
+| 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
+| 5 | TFDS | `project:tfds` | TFDS application and related services |
+| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
+| 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
+| 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
+| 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+
+If context doesn't clearly map to one project, ask the user before proceeding.
+
+### Backfill on Existing Issues/PRs
+
+When interacting with an issue or PR that has missing metadata:
+
+1. Add missing assignee (`laurigates`) and reviewer (`laurigates` for PRs — skip if author matches reviewer)
+2. Add missing type labels — infer from title and content
+3. Add to the appropriate project if not yet linked
+4. Inform the user what was added (do not silently modify)
+
+### Label Conventions
+
+Use these standard type labels consistently:
+
+| Label | When |
+|-------|------|
+| `bug` | Defect or broken behavior |
+| `enhancement` | New feature or improvement to existing feature |
+| `chore` | Maintenance, dependency updates, refactoring |
+| `docs` | Documentation changes |
+| `security` | Security-related fixes or improvements |
+
+Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.
+
+**No `triage` label.** The org does not currently define a `triage` label in `infrastructure/github/labels.tf`. For investigation-stage issues where the root cause is not yet confirmed, use the `bug` label with a `triage(scope): ...` conventional-commit title prefix to signal the diagnostic intent. Do not request a `triage` label be added without first confirming the workflow needs one — the title prefix has been sufficient in practice.
+
+**Labels are Terraform-managed.** Org-wide labels are defined in `infrastructure/github/labels.tf` (`local.standard_labels`). Do not create labels via `gh label create` — they will be destroyed on the next Terraform apply. To add a new label, add it to `labels.tf` and apply via Terraform Cloud (`infrastructure-github` workspace).

--- a/.github/instructions/local-development.instructions.md
+++ b/.github/instructions/local-development.instructions.md
@@ -52,3 +52,21 @@ Install and run:
 pre-commit install
 pre-commit run --all-files
 ```
+
+## Local ↔ CI Parity
+
+**Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
+
+Concrete patterns that help:
+
+- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
+- When CI adds a new check, update the matching local recipe in the same PR.
+
+**Known-acceptable deviations:** full parity isn't always feasible — heavy Playwright suites, integration tests requiring external services, or long-running security scans may be CI-only. When diverging intentionally:
+
+- Note it in the recipe comment or the job, so the next person understands the gap
+- Prefer a lighter local variant (e.g. `just test-unit` locally, full suite in CI) over nothing
+- Track "fix properly" work as an issue when the divergence is a temporary workaround (e.g. runner capacity), not a permanent design choice
+
+Don't enforce parity strictly during reviews — surface the gap, suggest a lighter local equivalent, and move on.


### PR DESCRIPTION
## Summary

Catches the generated tool outputs in `.claude/`, `.cursor/`, `.gemini/`, and `.github/instructions/` up to the canonical sources in `.rulesync/rules/`. Pure `rulesync generate` output — no rule content authored here.

## Changes

- Regenerate `local-development` for all four AI tools to pick up the "Local ↔ CI Parity" section that landed in source via #35 but never had its generated outputs committed.
- Regenerate `github-metadata-hygiene` for all four AI tools — #47 added only the `.rulesync/rules/` source; the matching generated files weren't included.

## Testing

- [x] `git diff` confirms changes are limited to generated files (and additions match the corresponding source content).
- [ ] Unit tests pass — N/A (docs-only)
- [x] Manual testing done — verified `local-development` generated files now contain the "Local ↔ CI Parity" section already present in the source.

## Related

Refs #35, #47.