### PR TITLE
docs(rulesync): add ci-cd workflow adoption audit guidance

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -140,7 +140,7 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
 
 - Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
-- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
 - Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
 
 Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.

--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -135,6 +135,16 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 | `a11y-aria.yml` | `reusable-a11y-aria.yml` | ARIA pattern correctness |
 | `a11y-wcag.yml` | `reusable-a11y-wcag.yml` | WCAG 2.1 compliance |
 
+## Adoption Audit
+
+When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
+
+- Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
+- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
+
+Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.
+
 ## Build-Once/Promote Pattern
 
 Container workflows use a two-phase pattern:

--- a/.cursor/rules/ci-cd-workflows.mdc
+++ b/.cursor/rules/ci-cd-workflows.mdc
@@ -141,7 +141,7 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
 
 - Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
-- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
 - Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
 
 Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.

--- a/.cursor/rules/ci-cd-workflows.mdc
+++ b/.cursor/rules/ci-cd-workflows.mdc
@@ -100,7 +100,7 @@ secrets:
 |-------|------|---------|-------------|
 | `runner` | string | `ubuntu-slim` | Runner label |
 | `max_turns` | number | `30` | Maximum agentic turns before stopping |
-| `claude_args` | string | `''` | Additional CLI arguments. These are appended after built-in arguments. Avoid passing arguments like `--max-turns` that are handled by dedicated inputs to prevent conflicts. |
+| `claude_args` | string | `''` | Additional CLI arguments (appended after built-in `--max-turns` and `--system-prompt`) |
 
 Example — increase turns for a large codebase:
 
@@ -135,6 +135,16 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 | `quality-typescript.yml` | `reusable-quality-typescript.yml` | TypeScript strictness |
 | `a11y-aria.yml` | `reusable-a11y-aria.yml` | ARIA pattern correctness |
 | `a11y-wcag.yml` | `reusable-a11y-wcag.yml` | WCAG 2.1 compliance |
+
+## Adoption Audit
+
+When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
+
+- Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
+- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
+
+Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.
 
 ## Build-Once/Promote Pattern
 

--- a/.gemini/memories/ci-cd-workflows.md
+++ b/.gemini/memories/ci-cd-workflows.md
@@ -136,7 +136,7 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
 
 - Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
-- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
 - Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
 
 Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.

--- a/.gemini/memories/ci-cd-workflows.md
+++ b/.gemini/memories/ci-cd-workflows.md
@@ -95,7 +95,7 @@ secrets:
 |-------|------|---------|-------------|
 | `runner` | string | `ubuntu-slim` | Runner label |
 | `max_turns` | number | `30` | Maximum agentic turns before stopping |
-| `claude_args` | string | `''` | Additional CLI arguments. These are appended after built-in arguments. Avoid passing arguments like `--max-turns` that are handled by dedicated inputs to prevent conflicts. |
+| `claude_args` | string | `''` | Additional CLI arguments (appended after built-in `--max-turns` and `--system-prompt`) |
 
 Example — increase turns for a large codebase:
 
@@ -130,6 +130,16 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 | `quality-typescript.yml` | `reusable-quality-typescript.yml` | TypeScript strictness |
 | `a11y-aria.yml` | `reusable-a11y-aria.yml` | ARIA pattern correctness |
 | `a11y-wcag.yml` | `reusable-a11y-wcag.yml` | WCAG 2.1 compliance |
+
+## Adoption Audit
+
+When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
+
+- Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
+- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
+
+Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.
 
 ## Build-Once/Promote Pattern
 

--- a/.github/instructions/ci-cd-workflows.instructions.md
+++ b/.github/instructions/ci-cd-workflows.instructions.md
@@ -140,7 +140,7 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
 
 - Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
-- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
 - Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
 
 Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.

--- a/.github/instructions/ci-cd-workflows.instructions.md
+++ b/.github/instructions/ci-cd-workflows.instructions.md
@@ -99,7 +99,7 @@ secrets:
 |-------|------|---------|-------------|
 | `runner` | string | `ubuntu-slim` | Runner label |
 | `max_turns` | number | `30` | Maximum agentic turns before stopping |
-| `claude_args` | string | `''` | Additional CLI arguments. These are appended after built-in arguments. Avoid passing arguments like `--max-turns` that are handled by dedicated inputs to prevent conflicts. |
+| `claude_args` | string | `''` | Additional CLI arguments (appended after built-in `--max-turns` and `--system-prompt`) |
 
 Example — increase turns for a large codebase:
 
@@ -134,6 +134,16 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 | `quality-typescript.yml` | `reusable-quality-typescript.yml` | TypeScript strictness |
 | `a11y-aria.yml` | `reusable-a11y-aria.yml` | ARIA pattern correctness |
 | `a11y-wcag.yml` | `reusable-a11y-wcag.yml` | WCAG 2.1 compliance |
+
+## Adoption Audit
+
+When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
+
+- Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
+- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
+
+Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.
 
 ## Build-Once/Promote Pattern
 

--- a/.rulesync/rules/ci-cd-workflows.md
+++ b/.rulesync/rules/ci-cd-workflows.md
@@ -142,7 +142,7 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
 
 - Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
-- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
 - Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
 
 Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.

--- a/.rulesync/rules/ci-cd-workflows.md
+++ b/.rulesync/rules/ci-cd-workflows.md
@@ -137,6 +137,16 @@ The workflow also injects a `--system-prompt` instructing Claude to commit and p
 | `a11y-aria.yml` | `reusable-a11y-aria.yml` | ARIA pattern correctness |
 | `a11y-wcag.yml` | `reusable-a11y-wcag.yml` | WCAG 2.1 compliance |
 
+## Adoption Audit
+
+When opening, editing, or reviewing a workflow file in any FVH application repo, briefly scan the rest of `.github/workflows/` and surface adoption gaps:
+
+- Inline build/release/security/quality logic that duplicates a reusable workflow → propose migrating to `uses: ForumViriumHelsinki/.github/...`.
+- Missing standard workflows for a deployed application (release-please, container build/release, image-updater auto-merge, claude).
+- Pinned `@<sha>` / `@v1` references to reusable workflows — confirm they are intentional vs. drift from `@main`.
+
+Surface findings in the response — do not silently rewrite unrelated workflow files. Migration to reusable workflows is a deliberate change. Workspace-wide adoption status is also visible via `just fvh::workflow-matrix` from the workspace root.
+
 ## Build-Once/Promote Pattern
 
 Container workflows use a two-phase pattern:


### PR DESCRIPTION
## Summary

Adds an "Adoption Audit" section to the `ci-cd-workflows` rule. When AI assistants touch a workflow in any FVH application repo, they're now instructed to briefly scan the rest of `.github/workflows/` and surface reusable-workflow adoption gaps — not silently rewrite unrelated files.

## Changes

- New "Adoption Audit" section in `.rulesync/rules/ci-cd-workflows.md` calling out three signals to surface:
  - Inline build/release/security/quality logic that duplicates a reusable workflow.
  - Missing standard workflows for a deployed application (release-please, renovate, container build/release, image-updater auto-merge, claude).
  - Pinned `@<sha>` / `@v1` references that may have drifted from `@main`.
- Mentions `just fvh::workflow-matrix` from the workspace root for portfolio-wide adoption status.
- Regenerated tool outputs for Claude Code, Cursor, Gemini, and Copilot instructions to match the source.

## Testing

- [ ] Unit tests pass — N/A (docs-only rule change)
- [x] Manual testing done — verified each generated file mirrors the new source section.

## Related

Stacks behind #49 (rulesync regen drift cleanup), but base is `main`; merge order doesn't matter functionally — both touch disjoint files.

Addresses Gemini review feedback (renovate inclusion).