### PR TITLE
docs(rulesync): tighten metadata-hygiene wording per Gemini review

### DIFF
--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -18,7 +18,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |

--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -28,7 +28,7 @@ Apply these checks when:
 
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
-| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Reviewer | If not author | `-r @laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
 | Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
 | Project | Always | `-p <title>` | Same project as linked issue |
@@ -38,7 +38,7 @@ Apply these checks when:
 
 ### Project Determination
 
-Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. When a corresponding `project:*` label is defined in the table below, always apply it when creating issues/PRs — this label drives automated project board routing.
 
 | # | Project | Label | Context Signals |
 |---|---------|-------|----------------|

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -19,7 +19,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -29,7 +29,7 @@ Apply these checks when:
 
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
-| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Reviewer | If not author | `-r @laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
 | Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
 | Project | Always | `-p <title>` | Same project as linked issue |
@@ -39,7 +39,7 @@ Apply these checks when:
 
 ### Project Determination
 
-Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. When a corresponding `project:*` label is defined in the table below, always apply it when creating issues/PRs — this label drives automated project board routing.
 
 | # | Project | Label | Context Signals |
 |---|---------|-------|----------------|

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -14,7 +14,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -24,7 +24,7 @@ Apply these checks when:
 
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
-| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Reviewer | If not author | `-r @laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
 | Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
 | Project | Always | `-p <title>` | Same project as linked issue |
@@ -34,7 +34,7 @@ Apply these checks when:
 
 ### Project Determination
 
-Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. When a corresponding `project:*` label is defined in the table below, always apply it when creating issues/PRs — this label drives automated project board routing.
 
 | # | Project | Label | Context Signals |
 |---|---------|-------|----------------|

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -30,7 +30,7 @@ Apply these checks when:
 
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
-| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Reviewer | If not author | `-r @laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
 | Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
 | Project | Always | `-p <title>` | Same project as linked issue |
@@ -40,7 +40,7 @@ Apply these checks when:
 
 ### Project Determination
 
-Match context to the appropriate org project. Use repository name, file paths, and task description as signals. Always apply the corresponding `project:*` label when creating issues/PRs — this label drives automated project board routing.
+Match context to the appropriate org project. Use repository name, file paths, and task description as signals. When a corresponding `project:*` label is defined in the table below, always apply it when creating issues/PRs — this label drives automated project board routing.
 
 | # | Project | Label | Context Signals |
 |---|---------|-------|----------------|

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -20,7 +20,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |

--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -30,7 +30,7 @@ Apply these checks when:
 
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
-| Reviewer | If not author | `-r laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
+| Reviewer | If not author | `-r @laurigates` | `laurigates` unless told otherwise; **skip if user is the PR author** (GitHub API rejects self-review requests with HTTP 422) |
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
 | Labels | Always | `-l <name>` | Match linked issue labels; add type label if missing |
 | Project | Always | `-p <title>` | Same project as linked issue |


### PR DESCRIPTION
## Summary

Addresses Gemini Code Assist's review rounds on `github-metadata-hygiene` files (originally stacked on #49; rebased onto `main` after #49 merged).

## Changes

- **Source — `@` consistency on reviewer flag.** Reviewer column now reads `` `-r @laurigates` `` to match the assignee column's `` `-a @laurigates` ``. Source plus all four generated files.
- **Generated — pull in stale source updates.** The generated files in #49 were re-rolled from a stale snapshot. Source updates that hadn't propagated:
  - "When a corresponding `project:*` label is defined in the table below, always apply it…" wording (handles the `Template: Epic` row that has no label).
  - `security` added to the Issue-Metadata-Checklist Labels-row defaults (`bug`, `enhancement`, `chore`, `docs`, `security`).

The second commit is a clean `npx rulesync@latest generate` run — no manual edits to generated files.

## Testing

- [ ] Unit tests pass — N/A (docs-only)
- [x] Manual testing done — `git diff origin/main` shows changes scoped to the hygiene files (1 source + 4 generated). Canonical regen via `npx rulesync@latest generate` produces no further drift.

## Related

Addresses Gemini review feedback on both #49 and #52.