### PR TITLE
fix(release): verify PR image is current before promoting

### DIFF
--- a/.github/workflows/reusable-container-build.yml
+++ b/.github/workflows/reusable-container-build.yml
@@ -108,6 +108,21 @@ jobs:
           TAG="ghcr.io/${{ inputs.image-name }}:next-${{ steps.version.outputs.version }}"
           echo "pre-release-tag=${TAG}" >> $GITHUB_OUTPUT
 
+      # Tree-hash of the build context at the commit being built. The release
+      # job uses this to detect main moving forward between PR build and release
+      # tag, which would otherwise cause a stale image to be promoted unchanged.
+      - name: Compute build context tree hash
+        id: tree
+        run: |
+          CONTEXT="${{ inputs.context }}"
+          if [ -z "$CONTEXT" ] || [ "$CONTEXT" = "." ]; then
+            TREE=$(git rev-parse "HEAD^{tree}")
+          else
+            TREE=$(git rev-parse "HEAD:${CONTEXT}")
+          fi
+          echo "hash=${TREE}" >> $GITHUB_OUTPUT
+          echo "Build context tree hash: ${TREE}"
+
       - name: Build and push pre-release image
         id: build-push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
@@ -117,6 +132,11 @@ jobs:
           platforms: ${{ inputs.platforms }}
           push: true
           tags: ${{ steps.tag.outputs.pre-release-tag }}
+          # Labels read by reusable-container-release.yml to verify the cached
+          # PR image is still current before promoting it to the release tag.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            fvh.build.context-tree=${{ steps.tree.outputs.hash }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -90,7 +90,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
       tags: ${{ steps.meta.outputs.tags }}
-      promoted: ${{ steps.pr-image.outputs.exists }}
+      promoted: ${{ steps.pr-image.outputs.exists == 'true' && steps.freshness.outputs.stale != 'true' }}
       signed: ${{ steps.cosign-sign.outputs.signed }}
     steps:
       - name: Checkout repository
@@ -127,10 +127,45 @@ jobs:
           if docker manifest inspect "${PR_IMAGE}" > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "image=${PR_IMAGE}" >> $GITHUB_OUTPUT
-            echo "PR image found — will promote instead of rebuilding"
+            echo "PR image found — will check freshness before promoting"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "PR image not found in GHCR — will fall back to full rebuild"
+          fi
+
+      # Guard against the build-once/promote race: if main moved forward between
+      # the PR image being built and the release tag being pushed, the cached
+      # PR image is stale and would silently ship the wrong code. We compare the
+      # build-context tree hash baked into the PR image's labels against the
+      # tree hash at the release commit.
+      - name: Verify PR image matches release commit
+        id: freshness
+        if: steps.pr-image.outputs.exists == 'true'
+        env:
+          PR_IMAGE: ${{ steps.pr-image.outputs.image }}
+          CONTEXT: ${{ inputs.context }}
+        run: |
+          set -euo pipefail
+          PR_TREE=$(docker buildx imagetools inspect "$PR_IMAGE" --format '{{json .Image}}' \
+            | jq -r '.config.Labels."fvh.build.context-tree" // empty')
+          if [ -z "$PR_TREE" ]; then
+            echo "::warning::PR image has no fvh.build.context-tree label (built before this guard landed) — falling back to rebuild"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$CONTEXT" ] || [ "$CONTEXT" = "." ]; then
+            RELEASE_TREE=$(git rev-parse "HEAD^{tree}")
+          else
+            RELEASE_TREE=$(git rev-parse "HEAD:${CONTEXT}")
+          fi
+          echo "PR image build context tree: ${PR_TREE}"
+          echo "Release commit context tree: ${RELEASE_TREE}"
+          if [ "$PR_TREE" = "$RELEASE_TREE" ]; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "Build context unchanged since PR image was built — safe to promote"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Build context changed since PR image was built — will rebuild from release commit"
           fi
 
       - name: Extract Docker metadata (release version tags)
@@ -150,7 +185,7 @@ jobs:
       # ---- Fast path: promote the pre-built PR image -------------------------
       # Manifest-only retag: no layer re-upload, completes in seconds.
       - name: Promote PR image to release tags
-        if: steps.pr-image.outputs.exists == 'true'
+        if: steps.pr-image.outputs.exists == 'true' && steps.freshness.outputs.stale != 'true'
         run: |
           SOURCE="${{ steps.pr-image.outputs.image }}"
           TAG_ARGS=()
@@ -161,10 +196,11 @@ jobs:
           docker buildx imagetools create "${TAG_ARGS[@]}" "$SOURCE"
 
       # ---- Slow path: full rebuild (fallback) --------------------------------
-      # Reached when the :next-{version} image is not in GHCR.
-      - name: Build and push (fallback — no pre-built PR image found)
+      # Reached when the :next-{version} image is not in GHCR, or when its
+      # build-context tree no longer matches the release commit.
+      - name: Build and push (fallback — PR image missing or stale)
         id: build-push
-        if: steps.pr-image.outputs.exists != 'true'
+        if: steps.pr-image.outputs.exists != 'true' || steps.freshness.outputs.stale == 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ inputs.context }}
@@ -225,16 +261,19 @@ jobs:
       - name: Job summary
         if: always()
         run: |
-          PROMOTED="${{ steps.pr-image.outputs.exists }}"
+          PR_IMAGE_EXISTS="${{ steps.pr-image.outputs.exists }}"
+          STALE="${{ steps.freshness.outputs.stale }}"
           SIGNED="${{ steps.cosign-sign.outputs.signed }}"
           DIGEST="${{ steps.release-digest.outputs.digest }}"
           echo "## Container Release: \`${{ inputs.image-name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: \`${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          if [ "$PROMOTED" = "true" ]; then
+          if [ "$PR_IMAGE_EXISTS" = "true" ] && [ "$STALE" != "true" ]; then
             echo "- **Method**: Promoted from pre-built PR image (fast path)" >> $GITHUB_STEP_SUMMARY
             echo "- **Source**: \`${{ steps.version.outputs.next_image }}\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$PR_IMAGE_EXISTS" = "true" ] && [ "$STALE" = "true" ]; then
+            echo "- **Method**: Full rebuild (PR image was stale — main moved between PR build and release)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- **Method**: Full rebuild (fallback)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Method**: Full rebuild (no pre-built PR image found)" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "$SIGNED" = "true" ]; then
             echo "- **Signing**: Signed with cosign (keyless/Sigstore)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

The build-once/promote pattern silently shipped stale images when `main` moved forward between the release-please PR's container build and the release tag being pushed. The release job blindly promoted whatever `:next-{version}` image was cached, so any commits that landed on `main` after the PR's container build (e.g. a hotfix to the Dockerfile) were absent from the published release image.

## Concrete failure (google-chat-agent 0.1.38)

| UTC | Event |
|---|---|
| 10:50:10 | Container Build (PR) for release-please PR #198 → `google-chat-agent:next-0.1.38` (without libgcc) |
| 10:56:32 | google-chat-agent#197 (install libgcc) merges to main |
| 10:57:00 | release-please PR #198 squash-merges; main HEAD now contains libgcc |
| 10:57:15 | Container Release retags `:next-0.1.38` as `:0.1.38` → published image is missing libgcc, pod crashes on startup with `Error loading shared library libgcc_s.so.1` |

## Fix

Each PR image now carries its build-context tree hash as an OCI label (`fvh.build.context-tree`). Before promoting, the release job reads that label and compares it to the tree hash of the same context at the release commit. If they differ, the cached image is stale and the job falls back to a full rebuild from the release commit.

Tree hashes are deterministic and don't require fetching the PR's ephemeral merge commit, so the check works regardless of merge strategy (squash/rebase/merge).

Images built before this lands have no `fvh.build.context-tree` label — those are treated as stale and rebuilt, so the guard is fail-safe during rollout.

## Test plan

- [ ] Next release-please PR's container build labels its `:next-{version}` image with `org.opencontainers.image.revision` and `fvh.build.context-tree` (verify via `docker buildx imagetools inspect <image> --format '{{json .Image}}'`)
- [ ] When a release tag is pushed and the cached PR image's tree hash matches the release commit's tree → promote (fast path, "Promoted from pre-built PR image")
- [ ] When a release tag is pushed and main has moved (e.g. a hotfix landed between PR build and release) → fall back to rebuild ("PR image was stale — main moved between PR build and release")
- [ ] First release after this lands won't have the label — falls back to rebuild with a `::warning::PR image has no fvh.build.context-tree label` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)