### PR TITLE
docs(rulesync): align type-label table with actual repo labels

### DIFF
--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -20,7 +20,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `documentation`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
@@ -75,7 +75,7 @@ Use these standard type labels consistently:
 | `bug` | Defect or broken behavior |
 | `enhancement` | New feature or improvement to existing feature |
 | `chore` | Maintenance, dependency updates, refactoring |
-| `docs` | Documentation changes |
+| `documentation` | Documentation changes |
 | `security` | Security-related fixes or improvements |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.


### PR DESCRIPTION
## Summary

Two one-line changes in `.rulesync/rules/github-metadata-hygiene.md`:

- Issue Metadata Checklist (line 23): `docs` → `documentation`
- Label Conventions table (line 78): `docs` → `documentation`

## Why

The hygiene rule listed `docs` as a standard type label, but no FVH repo has a `docs` label. GitHub's default is `documentation`, which is what `infrastructure/github/labels.tf` actually carries. Agents reading this rule applied `docs` and the label was silently dropped — confirmed today across 13 cleanup PRs (e.g. ForumViriumHelsinki/podio-mcp#117) where the `chore` label was also missing.

## Companion change

The `chore` label addition lives in ForumViriumHelsinki/infrastructure#1785 (Terraform-managed in `github/labels.tf`). After both PRs merge:

- `chore` exists on all repos
- The rule no longer references a non-existent `docs` label

## Test plan

- [ ] After merge, `rulesync generate` regenerates `.claude/rules/github-metadata-hygiene.md` in app workspaces with the updated table
- [ ] Future PR helpers will request `documentation` (which exists) rather than `docs` (which never did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)