### PR TITLE
docs(rulesync): add feature-flags rule and reverse-port workspace edits

### DIFF
--- a/.claude/rules/dependency-automation.md
+++ b/.claude/rules/dependency-automation.md
@@ -33,6 +33,8 @@ Renovate runs **from the infrastructure repo only**. Do NOT add Renovate workflo
 
 Application repos may have a `renovate.json` for configuration (e.g., custom grouping, automerge rules), but the workflow that triggers Renovate lives in the infrastructure repo.
 
+Renovate auto-generates a **Dependency Dashboard** issue in each managed repo. These are operational artifacts — **do not add them to GitHub Projects** and do not close them manually. Renovate manages their lifecycle.
+
 ## release-please
 
 Driven by conventional commits on the `main` branch:

--- a/.claude/rules/deploy-values.md
+++ b/.claude/rules/deploy-values.md
@@ -152,6 +152,22 @@ volumeMounts:
     mountPath: /tmp
 ```
 
+### Feature Flags (GoFeatureFlag)
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFEATUREFLAG_ENDPOINT env var automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Prefer GOFF over `ENABLE_*` / `FEATURE_*` env vars for any runtime toggle. See `.claude/rules/feature-flags.md` for the full pattern and evaluation key provisioning.
+
 ### Resource Requests and Limits
 
 ```yaml

--- a/.claude/rules/feature-flags.md
+++ b/.claude/rules/feature-flags.md
@@ -1,0 +1,85 @@
+---
+paths:
+  - '**/deploy/values.yaml'
+  - '**/deploy/**'
+  - '**/src/**'
+  - '**/.github/workflows/**'
+---
+# Feature Flags — GOFF + OpenFeature for Application Repos
+
+## Rule: Prefer GoFeatureFlag over environment variables for feature toggles
+
+When toggling features, conditional behavior, A/B testing, gradual rollouts, or kill switches — **always use GoFeatureFlag (GOFF) + OpenFeature SDK** rather than `ENABLE_*` / `FEATURE_*` environment variables or ConfigMap booleans.
+
+**Use GOFF when the toggle needs any of**: per-user targeting, percentage rollouts, instant rollback without redeploy, A/B testing, scheduled activation, or frequent changes.
+
+**Env vars remain correct for**: infrastructure config (DB URLs, ports), deploy-time settings (log level), secrets, and values that are identical for all users and only change at deploy time.
+
+The `/feature-flags` skill provides a full decision framework. Reference `docs/FEATURE_FLAGS.md` in the infrastructure repo for the onboarding guide.
+
+## Enabling GOFF in an Application
+
+### 1. `deploy/values.yaml`
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFF relay proxy endpoint automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Setting `featureFlags.enabled: true` in `helm-webapp` values automatically injects the `GOFEATUREFLAG_ENDPOINT` environment variable pointing to the internal relay proxy.
+
+### 2. ExternalSecret for the evaluation key
+
+```yaml
+externalSecret:
+  enabled: true
+  name: my-app-secrets
+  data:
+    - secretKey: GOFF_CLIENT_ID
+      remoteRef:
+        key: my-app-goff_client_id  # Provisioned in infrastructure repo
+```
+
+### 3. OpenFeature SDK (application code)
+
+Configure the GOFF provider with the evaluation key from the injected env vars:
+
+```python
+# Python example
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+
+api.set_provider(GoFeatureFlagProvider(
+    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
+    api_key=os.environ["GOFF_CLIENT_ID"],
+))
+```
+
+The OpenFeature GOFF provider handles `X-API-Key` header injection automatically.
+
+## Evaluation Key Provisioning
+
+Each application gets a **dedicated evaluation key** for independent revocation. Provisioning requires infrastructure repo changes (Terraform + ExternalSecret aggregation).
+
+**To request a key**: open an issue in the infrastructure repo referencing `@infrastructure/.claude/rules/feature-flags.md` for the provisioning checklist.
+
+Keys propagate via:
+```
+GCP Secret Manager → External Secrets Operator → K8s Secret → GOFF relay proxy
+```
+
+New keys take up to **1 hour** to propagate (ExternalSecret refresh interval).
+
+## Key Principles
+
+- **Never use env vars for runtime feature toggles** — use GOFF flags instead
+- **Never hardcode evaluation keys** — always via ExternalSecret from GCP Secret Manager
+- **One key per app** — enables independent revocation
+- **Client-side evaluation** (browser extensions, etc.) passes the key directly via `X-API-Key`

--- a/.claude/rules/feature-flags.md
+++ b/.claude/rules/feature-flags.md
@@ -52,13 +52,13 @@ externalSecret:
 Configure the GOFF provider with the evaluation key from the injected env vars:
 
 ```python
-# Python example
+import os
 from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.gofeatureflag import GoFeatureFlagProvider
 
 api.set_provider(GoFeatureFlagProvider(
-    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
-    api_key=os.environ["GOFF_CLIENT_ID"],
+    endpoint=os.environ.get("GOFEATUREFLAG_ENDPOINT"),
+    api_key=os.environ.get("GOFF_CLIENT_ID"),
 ))
 ```
 

--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -18,7 +18,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `documentation`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
@@ -73,7 +73,7 @@ Use these standard type labels consistently:
 | `bug` | Defect or broken behavior |
 | `enhancement` | New feature or improvement to existing feature |
 | `chore` | Maintenance, dependency updates, refactoring |
-| `docs` | Documentation changes |
+| `documentation` | Documentation changes |
 | `security` | Security-related fixes or improvements |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.

--- a/.cursor/rules/dependency-automation.mdc
+++ b/.cursor/rules/dependency-automation.mdc
@@ -31,6 +31,8 @@ Renovate runs **from the infrastructure repo only**. Do NOT add Renovate workflo
 
 Application repos may have a `renovate.json` for configuration (e.g., custom grouping, automerge rules), but the workflow that triggers Renovate lives in the infrastructure repo.
 
+Renovate auto-generates a **Dependency Dashboard** issue in each managed repo. These are operational artifacts — **do not add them to GitHub Projects** and do not close them manually. Renovate manages their lifecycle.
+
 ## release-please
 
 Driven by conventional commits on the `main` branch:

--- a/.cursor/rules/deploy-values.mdc
+++ b/.cursor/rules/deploy-values.mdc
@@ -152,6 +152,22 @@ volumeMounts:
     mountPath: /tmp
 ```
 
+### Feature Flags (GoFeatureFlag)
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFEATUREFLAG_ENDPOINT env var automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Prefer GOFF over `ENABLE_*` / `FEATURE_*` env vars for any runtime toggle. See `.claude/rules/feature-flags.md` for the full pattern and evaluation key provisioning.
+
 ### Resource Requests and Limits
 
 ```yaml

--- a/.cursor/rules/feature-flags.mdc
+++ b/.cursor/rules/feature-flags.mdc
@@ -50,13 +50,13 @@ externalSecret:
 Configure the GOFF provider with the evaluation key from the injected env vars:
 
 ```python
-# Python example
+import os
 from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.gofeatureflag import GoFeatureFlagProvider
 
 api.set_provider(GoFeatureFlagProvider(
-    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
-    api_key=os.environ["GOFF_CLIENT_ID"],
+    endpoint=os.environ.get("GOFEATUREFLAG_ENDPOINT"),
+    api_key=os.environ.get("GOFF_CLIENT_ID"),
 ))
 ```
 

--- a/.cursor/rules/feature-flags.mdc
+++ b/.cursor/rules/feature-flags.mdc
@@ -1,0 +1,83 @@
+---
+description: Feature flag pattern for FVH application repos — GoFeatureFlag + OpenFeature SDK
+globs: **/deploy/values.yaml,**/deploy/**,**/src/**,**/.github/workflows/**
+---
+
+# Feature Flags — GOFF + OpenFeature for Application Repos
+
+## Rule: Prefer GoFeatureFlag over environment variables for feature toggles
+
+When toggling features, conditional behavior, A/B testing, gradual rollouts, or kill switches — **always use GoFeatureFlag (GOFF) + OpenFeature SDK** rather than `ENABLE_*` / `FEATURE_*` environment variables or ConfigMap booleans.
+
+**Use GOFF when the toggle needs any of**: per-user targeting, percentage rollouts, instant rollback without redeploy, A/B testing, scheduled activation, or frequent changes.
+
+**Env vars remain correct for**: infrastructure config (DB URLs, ports), deploy-time settings (log level), secrets, and values that are identical for all users and only change at deploy time.
+
+The `/feature-flags` skill provides a full decision framework. Reference `docs/FEATURE_FLAGS.md` in the infrastructure repo for the onboarding guide.
+
+## Enabling GOFF in an Application
+
+### 1. `deploy/values.yaml`
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFF relay proxy endpoint automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Setting `featureFlags.enabled: true` in `helm-webapp` values automatically injects the `GOFEATUREFLAG_ENDPOINT` environment variable pointing to the internal relay proxy.
+
+### 2. ExternalSecret for the evaluation key
+
+```yaml
+externalSecret:
+  enabled: true
+  name: my-app-secrets
+  data:
+    - secretKey: GOFF_CLIENT_ID
+      remoteRef:
+        key: my-app-goff_client_id  # Provisioned in infrastructure repo
+```
+
+### 3. OpenFeature SDK (application code)
+
+Configure the GOFF provider with the evaluation key from the injected env vars:
+
+```python
+# Python example
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+
+api.set_provider(GoFeatureFlagProvider(
+    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
+    api_key=os.environ["GOFF_CLIENT_ID"],
+))
+```
+
+The OpenFeature GOFF provider handles `X-API-Key` header injection automatically.
+
+## Evaluation Key Provisioning
+
+Each application gets a **dedicated evaluation key** for independent revocation. Provisioning requires infrastructure repo changes (Terraform + ExternalSecret aggregation).
+
+**To request a key**: open an issue in the infrastructure repo referencing `@infrastructure/.claude/rules/feature-flags.md` for the provisioning checklist.
+
+Keys propagate via:
+```
+GCP Secret Manager → External Secrets Operator → K8s Secret → GOFF relay proxy
+```
+
+New keys take up to **1 hour** to propagate (ExternalSecret refresh interval).
+
+## Key Principles
+
+- **Never use env vars for runtime feature toggles** — use GOFF flags instead
+- **Never hardcode evaluation keys** — always via ExternalSecret from GCP Secret Manager
+- **One key per app** — enables independent revocation
+- **Client-side evaluation** (browser extensions, etc.) passes the key directly via `X-API-Key`

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -19,7 +19,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `documentation`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
@@ -74,7 +74,7 @@ Use these standard type labels consistently:
 | `bug` | Defect or broken behavior |
 | `enhancement` | New feature or improvement to existing feature |
 | `chore` | Maintenance, dependency updates, refactoring |
-| `docs` | Documentation changes |
+| `documentation` | Documentation changes |
 | `security` | Security-related fixes or improvements |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.

--- a/.gemini/memories/dependency-automation.md
+++ b/.gemini/memories/dependency-automation.md
@@ -26,6 +26,8 @@ Renovate runs **from the infrastructure repo only**. Do NOT add Renovate workflo
 
 Application repos may have a `renovate.json` for configuration (e.g., custom grouping, automerge rules), but the workflow that triggers Renovate lives in the infrastructure repo.
 
+Renovate auto-generates a **Dependency Dashboard** issue in each managed repo. These are operational artifacts — **do not add them to GitHub Projects** and do not close them manually. Renovate manages their lifecycle.
+
 ## release-please
 
 Driven by conventional commits on the `main` branch:

--- a/.gemini/memories/deploy-values.md
+++ b/.gemini/memories/deploy-values.md
@@ -147,6 +147,22 @@ volumeMounts:
     mountPath: /tmp
 ```
 
+### Feature Flags (GoFeatureFlag)
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFEATUREFLAG_ENDPOINT env var automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Prefer GOFF over `ENABLE_*` / `FEATURE_*` env vars for any runtime toggle. See `.claude/rules/feature-flags.md` for the full pattern and evaluation key provisioning.
+
 ### Resource Requests and Limits
 
 ```yaml

--- a/.gemini/memories/feature-flags.md
+++ b/.gemini/memories/feature-flags.md
@@ -45,13 +45,13 @@ externalSecret:
 Configure the GOFF provider with the evaluation key from the injected env vars:
 
 ```python
-# Python example
+import os
 from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.gofeatureflag import GoFeatureFlagProvider
 
 api.set_provider(GoFeatureFlagProvider(
-    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
-    api_key=os.environ["GOFF_CLIENT_ID"],
+    endpoint=os.environ.get("GOFEATUREFLAG_ENDPOINT"),
+    api_key=os.environ.get("GOFF_CLIENT_ID"),
 ))
 ```
 

--- a/.gemini/memories/feature-flags.md
+++ b/.gemini/memories/feature-flags.md
@@ -1,0 +1,78 @@
+# Feature Flags — GOFF + OpenFeature for Application Repos
+
+## Rule: Prefer GoFeatureFlag over environment variables for feature toggles
+
+When toggling features, conditional behavior, A/B testing, gradual rollouts, or kill switches — **always use GoFeatureFlag (GOFF) + OpenFeature SDK** rather than `ENABLE_*` / `FEATURE_*` environment variables or ConfigMap booleans.
+
+**Use GOFF when the toggle needs any of**: per-user targeting, percentage rollouts, instant rollback without redeploy, A/B testing, scheduled activation, or frequent changes.
+
+**Env vars remain correct for**: infrastructure config (DB URLs, ports), deploy-time settings (log level), secrets, and values that are identical for all users and only change at deploy time.
+
+The `/feature-flags` skill provides a full decision framework. Reference `docs/FEATURE_FLAGS.md` in the infrastructure repo for the onboarding guide.
+
+## Enabling GOFF in an Application
+
+### 1. `deploy/values.yaml`
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFF relay proxy endpoint automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Setting `featureFlags.enabled: true` in `helm-webapp` values automatically injects the `GOFEATUREFLAG_ENDPOINT` environment variable pointing to the internal relay proxy.
+
+### 2. ExternalSecret for the evaluation key
+
+```yaml
+externalSecret:
+  enabled: true
+  name: my-app-secrets
+  data:
+    - secretKey: GOFF_CLIENT_ID
+      remoteRef:
+        key: my-app-goff_client_id  # Provisioned in infrastructure repo
+```
+
+### 3. OpenFeature SDK (application code)
+
+Configure the GOFF provider with the evaluation key from the injected env vars:
+
+```python
+# Python example
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+
+api.set_provider(GoFeatureFlagProvider(
+    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
+    api_key=os.environ["GOFF_CLIENT_ID"],
+))
+```
+
+The OpenFeature GOFF provider handles `X-API-Key` header injection automatically.
+
+## Evaluation Key Provisioning
+
+Each application gets a **dedicated evaluation key** for independent revocation. Provisioning requires infrastructure repo changes (Terraform + ExternalSecret aggregation).
+
+**To request a key**: open an issue in the infrastructure repo referencing `@infrastructure/.claude/rules/feature-flags.md` for the provisioning checklist.
+
+Keys propagate via:
+```
+GCP Secret Manager → External Secrets Operator → K8s Secret → GOFF relay proxy
+```
+
+New keys take up to **1 hour** to propagate (ExternalSecret refresh interval).
+
+## Key Principles
+
+- **Never use env vars for runtime feature toggles** — use GOFF flags instead
+- **Never hardcode evaluation keys** — always via ExternalSecret from GCP Secret Manager
+- **One key per app** — enables independent revocation
+- **Client-side evaluation** (browser extensions, etc.) passes the key directly via `X-API-Key`

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -14,7 +14,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `documentation`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
@@ -69,7 +69,7 @@ Use these standard type labels consistently:
 | `bug` | Defect or broken behavior |
 | `enhancement` | New feature or improvement to existing feature |
 | `chore` | Maintenance, dependency updates, refactoring |
-| `docs` | Documentation changes |
+| `documentation` | Documentation changes |
 | `security` | Security-related fixes or improvements |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.

--- a/.github/instructions/dependency-automation.instructions.md
+++ b/.github/instructions/dependency-automation.instructions.md
@@ -33,6 +33,8 @@ Renovate runs **from the infrastructure repo only**. Do NOT add Renovate workflo
 
 Application repos may have a `renovate.json` for configuration (e.g., custom grouping, automerge rules), but the workflow that triggers Renovate lives in the infrastructure repo.
 
+Renovate auto-generates a **Dependency Dashboard** issue in each managed repo. These are operational artifacts — **do not add them to GitHub Projects** and do not close them manually. Renovate manages their lifecycle.
+
 ## release-please
 
 Driven by conventional commits on the `main` branch:

--- a/.github/instructions/deploy-values.instructions.md
+++ b/.github/instructions/deploy-values.instructions.md
@@ -151,6 +151,22 @@ volumeMounts:
     mountPath: /tmp
 ```
 
+### Feature Flags (GoFeatureFlag)
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFEATUREFLAG_ENDPOINT env var automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Prefer GOFF over `ENABLE_*` / `FEATURE_*` env vars for any runtime toggle. See `.claude/rules/feature-flags.md` for the full pattern and evaluation key provisioning.
+
 ### Resource Requests and Limits
 
 ```yaml

--- a/.github/instructions/feature-flags.instructions.md
+++ b/.github/instructions/feature-flags.instructions.md
@@ -1,0 +1,84 @@
+---
+description: >-
+  Feature flag pattern for FVH application repos — GoFeatureFlag + OpenFeature
+  SDK
+applyTo: '**/deploy/values.yaml,**/deploy/**,**/src/**,**/.github/workflows/**'
+---
+# Feature Flags — GOFF + OpenFeature for Application Repos
+
+## Rule: Prefer GoFeatureFlag over environment variables for feature toggles
+
+When toggling features, conditional behavior, A/B testing, gradual rollouts, or kill switches — **always use GoFeatureFlag (GOFF) + OpenFeature SDK** rather than `ENABLE_*` / `FEATURE_*` environment variables or ConfigMap booleans.
+
+**Use GOFF when the toggle needs any of**: per-user targeting, percentage rollouts, instant rollback without redeploy, A/B testing, scheduled activation, or frequent changes.
+
+**Env vars remain correct for**: infrastructure config (DB URLs, ports), deploy-time settings (log level), secrets, and values that are identical for all users and only change at deploy time.
+
+The `/feature-flags` skill provides a full decision framework. Reference `docs/FEATURE_FLAGS.md` in the infrastructure repo for the onboarding guide.
+
+## Enabling GOFF in an Application
+
+### 1. `deploy/values.yaml`
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFF relay proxy endpoint automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Setting `featureFlags.enabled: true` in `helm-webapp` values automatically injects the `GOFEATUREFLAG_ENDPOINT` environment variable pointing to the internal relay proxy.
+
+### 2. ExternalSecret for the evaluation key
+
+```yaml
+externalSecret:
+  enabled: true
+  name: my-app-secrets
+  data:
+    - secretKey: GOFF_CLIENT_ID
+      remoteRef:
+        key: my-app-goff_client_id  # Provisioned in infrastructure repo
+```
+
+### 3. OpenFeature SDK (application code)
+
+Configure the GOFF provider with the evaluation key from the injected env vars:
+
+```python
+# Python example
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+
+api.set_provider(GoFeatureFlagProvider(
+    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
+    api_key=os.environ["GOFF_CLIENT_ID"],
+))
+```
+
+The OpenFeature GOFF provider handles `X-API-Key` header injection automatically.
+
+## Evaluation Key Provisioning
+
+Each application gets a **dedicated evaluation key** for independent revocation. Provisioning requires infrastructure repo changes (Terraform + ExternalSecret aggregation).
+
+**To request a key**: open an issue in the infrastructure repo referencing `@infrastructure/.claude/rules/feature-flags.md` for the provisioning checklist.
+
+Keys propagate via:
+```
+GCP Secret Manager → External Secrets Operator → K8s Secret → GOFF relay proxy
+```
+
+New keys take up to **1 hour** to propagate (ExternalSecret refresh interval).
+
+## Key Principles
+
+- **Never use env vars for runtime feature toggles** — use GOFF flags instead
+- **Never hardcode evaluation keys** — always via ExternalSecret from GCP Secret Manager
+- **One key per app** — enables independent revocation
+- **Client-side evaluation** (browser extensions, etc.) passes the key directly via `X-API-Key`

--- a/.github/instructions/feature-flags.instructions.md
+++ b/.github/instructions/feature-flags.instructions.md
@@ -51,13 +51,13 @@ externalSecret:
 Configure the GOFF provider with the evaluation key from the injected env vars:
 
 ```python
-# Python example
+import os
 from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.gofeatureflag import GoFeatureFlagProvider
 
 api.set_provider(GoFeatureFlagProvider(
-    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
-    api_key=os.environ["GOFF_CLIENT_ID"],
+    endpoint=os.environ.get("GOFEATUREFLAG_ENDPOINT"),
+    api_key=os.environ.get("GOFF_CLIENT_ID"),
 ))
 ```
 

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -20,7 +20,7 @@ Apply these checks when:
 | Field | Required | How to Set | Default |
 |-------|----------|-----------|---------|
 | Assignee | Always | `-a @laurigates` | `laurigates` unless told otherwise |
-| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `docs`, `security` |
+| Labels | Always | `-l <name>` | At minimum a type label: `bug`, `enhancement`, `chore`, `documentation`, `security` |
 | Project | Always | `-p <title>` | Determine from context (see project table below); ask if ambiguous |
 | Milestone | If exists | `--milestone <name>` | Set if a relevant milestone exists for the repo |
 | Issue type | If supported | MCP `issue_write` with `type` param | Check `list_issue_types` for the org first |
@@ -75,7 +75,7 @@ Use these standard type labels consistently:
 | `bug` | Defect or broken behavior |
 | `enhancement` | New feature or improvement to existing feature |
 | `chore` | Maintenance, dependency updates, refactoring |
-| `docs` | Documentation changes |
+| `documentation` | Documentation changes |
 | `security` | Security-related fixes or improvements |
 
 Check available labels with `gh label list -R <owner>/<repo>` before applying — do not create labels that don't exist without asking.

--- a/.rulesync/rules/dependency-automation.md
+++ b/.rulesync/rules/dependency-automation.md
@@ -32,6 +32,8 @@ Renovate runs **from the infrastructure repo only**. Do NOT add Renovate workflo
 
 Application repos may have a `renovate.json` for configuration (e.g., custom grouping, automerge rules), but the workflow that triggers Renovate lives in the infrastructure repo.
 
+Renovate auto-generates a **Dependency Dashboard** issue in each managed repo. These are operational artifacts — **do not add them to GitHub Projects** and do not close them manually. Renovate manages their lifecycle.
+
 ## release-please
 
 Driven by conventional commits on the `main` branch:

--- a/.rulesync/rules/deploy-values.md
+++ b/.rulesync/rules/deploy-values.md
@@ -153,6 +153,22 @@ volumeMounts:
     mountPath: /tmp
 ```
 
+### Feature Flags (GoFeatureFlag)
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFEATUREFLAG_ENDPOINT env var automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Prefer GOFF over `ENABLE_*` / `FEATURE_*` env vars for any runtime toggle. See `.claude/rules/feature-flags.md` for the full pattern and evaluation key provisioning.
+
 ### Resource Requests and Limits
 
 ```yaml

--- a/.rulesync/rules/feature-flags.md
+++ b/.rulesync/rules/feature-flags.md
@@ -1,0 +1,84 @@
+---
+root: false
+targets: ["claudecode", "copilot", "geminicli", "cursor"]
+description: "Feature flag pattern for FVH application repos — GoFeatureFlag + OpenFeature SDK"
+globs: ["**/deploy/values.yaml", "**/deploy/**", "**/src/**", "**/.github/workflows/**"]
+---
+# Feature Flags — GOFF + OpenFeature for Application Repos
+
+## Rule: Prefer GoFeatureFlag over environment variables for feature toggles
+
+When toggling features, conditional behavior, A/B testing, gradual rollouts, or kill switches — **always use GoFeatureFlag (GOFF) + OpenFeature SDK** rather than `ENABLE_*` / `FEATURE_*` environment variables or ConfigMap booleans.
+
+**Use GOFF when the toggle needs any of**: per-user targeting, percentage rollouts, instant rollback without redeploy, A/B testing, scheduled activation, or frequent changes.
+
+**Env vars remain correct for**: infrastructure config (DB URLs, ports), deploy-time settings (log level), secrets, and values that are identical for all users and only change at deploy time.
+
+The `/feature-flags` skill provides a full decision framework. Reference `docs/FEATURE_FLAGS.md` in the infrastructure repo for the onboarding guide.
+
+## Enabling GOFF in an Application
+
+### 1. `deploy/values.yaml`
+
+```yaml
+featureFlags:
+  enabled: true  # Injects GOFF relay proxy endpoint automatically
+
+env:
+  - name: GOFF_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: my-app-secrets
+        key: GOFF_CLIENT_ID
+```
+
+Setting `featureFlags.enabled: true` in `helm-webapp` values automatically injects the `GOFEATUREFLAG_ENDPOINT` environment variable pointing to the internal relay proxy.
+
+### 2. ExternalSecret for the evaluation key
+
+```yaml
+externalSecret:
+  enabled: true
+  name: my-app-secrets
+  data:
+    - secretKey: GOFF_CLIENT_ID
+      remoteRef:
+        key: my-app-goff_client_id  # Provisioned in infrastructure repo
+```
+
+### 3. OpenFeature SDK (application code)
+
+Configure the GOFF provider with the evaluation key from the injected env vars:
+
+```python
+# Python example
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+
+api.set_provider(GoFeatureFlagProvider(
+    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
+    api_key=os.environ["GOFF_CLIENT_ID"],
+))
+```
+
+The OpenFeature GOFF provider handles `X-API-Key` header injection automatically.
+
+## Evaluation Key Provisioning
+
+Each application gets a **dedicated evaluation key** for independent revocation. Provisioning requires infrastructure repo changes (Terraform + ExternalSecret aggregation).
+
+**To request a key**: open an issue in the infrastructure repo referencing `@infrastructure/.claude/rules/feature-flags.md` for the provisioning checklist.
+
+Keys propagate via:
+```
+GCP Secret Manager → External Secrets Operator → K8s Secret → GOFF relay proxy
+```
+
+New keys take up to **1 hour** to propagate (ExternalSecret refresh interval).
+
+## Key Principles
+
+- **Never use env vars for runtime feature toggles** — use GOFF flags instead
+- **Never hardcode evaluation keys** — always via ExternalSecret from GCP Secret Manager
+- **One key per app** — enables independent revocation
+- **Client-side evaluation** (browser extensions, etc.) passes the key directly via `X-API-Key`

--- a/.rulesync/rules/feature-flags.md
+++ b/.rulesync/rules/feature-flags.md
@@ -51,13 +51,13 @@ externalSecret:
 Configure the GOFF provider with the evaluation key from the injected env vars:
 
 ```python
-# Python example
+import os
 from openfeature import api
-from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.gofeatureflag import GoFeatureFlagProvider
 
 api.set_provider(GoFeatureFlagProvider(
-    endpoint=os.environ["GOFEATUREFLAG_ENDPOINT"],
-    api_key=os.environ["GOFF_CLIENT_ID"],
+    endpoint=os.environ.get("GOFEATUREFLAG_ENDPOINT"),
+    api_key=os.environ.get("GOFF_CLIENT_ID"),
 ))
 ```
 


### PR DESCRIPTION
## Summary

Reverse-ports rule content that had been hand-edited in the FVH workspace `.claude/rules/` back into the canonical `.rulesync/rules/` source, so it survives the next `rulesync generate` and propagates to all FVH application repos via `reusable-sync-ai-rules.yml`.

Three commits, distinct concerns:

1. **`feat(rulesync): add feature-flags rule for application repos`** — new `.rulesync/rules/feature-flags.md` documenting the GoFeatureFlag (GOFF) + OpenFeature SDK pattern for FVH app repos: when to use GOFF vs env vars, the `featureFlags.enabled` toggle in helm-webapp values, ExternalSecret + OpenFeature wiring, and how to request a dedicated evaluation key. Also adds a short Feature Flags subsection to `deploy-values.md` that points at the new rule. Companion to the existing `infrastructure/.claude/rules/feature-flags.md` (which covers the provisioning-side concerns); this one ships to consumers.

2. **`docs(rulesync): flag Renovate dependency-dashboard issues as operational`** — one paragraph in `dependency-automation.md` noting that Renovate-generated Dependency Dashboard issues are operational artifacts, not backlog items; do not add to GitHub Projects, do not close manually. Avoids agent triage churn.

3. **`chore(rulesync): regenerate stale github-metadata-hygiene outputs`** — pure regeneration catch-up. PR #54 changed the source rule (`docs` → `documentation`) without running `rulesync generate`, so the four tool outputs (`.claude/`, `.cursor/`, `.gemini/`, `.github/instructions/`) lagged behind. No rule content authored in this commit.

## Test plan

- [x] `npx rulesync@latest generate` produces clean output (16 rules written across 4 tool targets)
- [x] `git diff` confirms regenerated outputs match the source edits — no unexpected changes
- [x] Workspace `/Users/lgates/repos/ForumViriumHelsinki/.claude/rules/` byte-matches the regenerated `.github/.claude/rules/` after copy
- [ ] Once merged, `reusable-sync-ai-rules.yml` runs in app repos and produces the expected sync PRs (verified post-merge)

## Notes

- The workspace also had a release-please section condensation linking to `~/.claude/rules/release-please.md`. That path is personal to one developer's local machine and shouldn't propagate to all FVH repos, so it was deliberately not ported.
- The root-level `just rules-drift` recipe will still report drift after this lands, because it byte-diffs `.github/.rulesync/rules/` (source frontmatter) against the workspace `.claude/rules/` (Claude-format frontmatter). The two will never byte-match by design — the recipe should diff against `.github/.claude/rules/` (the rulesync output) instead. Worth fixing as a follow-up in the workspace justfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)