### PR TITLE
docs(rulesync): add project:cost-attribution to project routing table

### DIFF
--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -54,7 +54,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
-| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, monthly cost reports, FinOps tooling |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, cost attribution, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 

--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -54,6 +54,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 


### PR DESCRIPTION
## Summary

Adds row 11 to the Project Determination table in `github-metadata-hygiene` for the new Cost Attribution Tooling project. Source-only edit; tool-specific outputs (`.claude/`, `.cursor/`, `.gemini/`, `.github/instructions/`) ship via the next `chore(rulesync) regenerate stale tool outputs` sweep, consistent with #54.

## Context

- Project board #11: https://github.com/orgs/ForumViriumHelsinki/projects/11
- Repo: https://github.com/ForumViriumHelsinki/fvh-cost-attribution
- Label provisioning: ForumViriumHelsinki/infrastructure#1803 (merged 2026-05-11; `project:cost-attribution` now in `local.standard_labels`)

## Test plan

- [ ] Source diff is one row added at position 11
- [ ] Next `rulesync generate` regen sweep propagates to `.claude/rules/`, `.cursor/rules/`, `.gemini/memories/`, and `.github/instructions/` copies (in this repo + downstream via `reusable-sync-ai-rules.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)