### PR TITLE
fix(workflows): bump trivy-action 0.34.0 → 0.36.0

### DIFF
--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -252,7 +252,7 @@ jobs:
           echo "signed=true" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # 0.36.0
         with:
           image-ref: ghcr.io/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
           format: 'table'


### PR DESCRIPTION
## Summary

- aquasecurity yanked Trivy **v0.69.1** from GitHub releases (only v0.69.0, v0.69.2, v0.69.3, v0.70.0 remain). `trivy-action@0.34.0` pins `setup-trivy` to install that exact yanked version, so every release run currently fails at the post-promotion vuln scan step with a silent download 404.
- Bumping to `trivy-action@0.36.0` (SHA `a9c7b0f0…`) brings in Trivy **v0.70.0** and restores the scan. No other behaviour changes for our `image-ref` / `format: table` / `severity` usage.

## Evidence

Failing run (R4C-Cesium-Viewer 1.51.0 release): https://github.com/ForumViriumHelsinki/R4C-Cesium-Viewer/actions/runs/26508704877/job/78067793072

Relevant log excerpt — install.sh confirms it asked for v0.69.1, then exits 1:

```
aquasecurity/trivy info checking GitHub for tag 'v0.69.1'
aquasecurity/trivy info found version: 0.69.1 for v0.69.1/Linux/64bit
##[error]Process completed with exit code 1.
```

`gh api repos/aquasecurity/trivy/releases/tags/v0.69.1` → 404.

Note that image promotion + cosign signing both succeeded before this step — published releases are not blocked, only the post-release scan fails. The workflow being marked failed is the user-visible symptom.

## Scope

Affects every FVH repo consuming `reusable-container-release.yml` on a release tag. One-line bump in this repo unblocks all of them.

## Test plan

- [ ] Re-run the failed R4C-Cesium-Viewer release workflow after merge to confirm Trivy installs and scans cleanly.
- [ ] Next regular release in any FVH repo passes the Trivy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)