### PR TITLE
feat(auto-merge): support GitHub App token for image-updater PR approval

### DIFF
--- a/.github/workflows/reusable-auto-merge-image-updater.yml
+++ b/.github/workflows/reusable-auto-merge-image-updater.yml
@@ -24,9 +24,17 @@ on:
         required: false
         type: string
         default: 'build: automatic image update'
+      app-id:
+        description: 'GitHub App ID. When set, generates an App installation token (via APP_PRIVATE_KEY) for PR creation/approval instead of AUTO_MERGE_PAT.'
+        required: false
+        type: string
+        default: ''
     secrets:
       AUTO_MERGE_PAT:
-        description: 'PAT for approving the PR (needs a different user from the PR author)'
+        description: 'PAT for approving the PR (needs a different user from the PR author). Required when app-id is empty and branch protection requires an approval.'
+        required: false
+      APP_PRIVATE_KEY:
+        description: 'GitHub App private key. Required when app-id is set.'
         required: false
 
 permissions:
@@ -38,6 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: inputs.app-id != ''
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         id: create-pr
@@ -61,9 +77,13 @@ jobs:
           echo "Created/found PR: $PR_URL"
 
       - name: Approve PR
+        # Approval comes from an identity other than the PR author
+        # (github-actions[bot], which created the PR above): the CI GitHub App
+        # token when app-id is set, otherwise AUTO_MERGE_PAT. Best-effort —
+        # auto-merge proceeds on its own when no approval is required.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
         run: gh pr review --approve "${{ github.ref_name }}"
 
       - name: Enable auto-merge


### PR DESCRIPTION
Adds optional GitHub App-token support to `reusable-auto-merge-image-updater.yml`, mirroring what `reusable-release-please.yml` already does. Lets application repos approve their ArgoCD Image Updater PRs via the org **CI GitHub App** (`forumviriumhelsinki-ci`) instead of a long-lived `AUTO_MERGE_PAT`.

## Change

- New optional `app-id` input + `APP_PRIVATE_KEY` secret.
- When `app-id` is set, a `Generate GitHub App token` step mints a short-lived installation token (`actions/create-github-app-token`, pinned).
- The **Approve PR** step coalesces app-token → `AUTO_MERGE_PAT` → `GITHUB_TOKEN`, so approval comes from a non-author identity.

## Backward compatibility

Fully additive. Existing callers that pass `AUTO_MERGE_PAT` (or neither) are unaffected — the new inputs are optional and default to empty.

## Why

The EzPolls reference app authenticates all CI/CD via the CI GitHub App (no PATs). Its `auto-merge-image-updater.yml` passes the org `CI_APP_ID` variable and `CI_APP_PRIVATE_KEY` secret, which this PR makes the reusable workflow accept.

Companion: **ForumViriumHelsinki/infrastructure#1877** (EzPolls deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
