### PR TITLE
docs(rules): correct auto-merge auth and CI App var names in ci-cd-workflows

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -24,7 +24,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
-| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` |
+| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` or `app-id` + `APP_PRIVATE_KEY` |
 | `claude.yml` | `reusable-claude.yml` | Issue/PR @-mentions | `CLAUDE_CODE_OAUTH_TOKEN` |
 
 ### Release-Please Workflow Inputs
@@ -49,9 +49,9 @@ Example — App-token caller (infrastructure repo):
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
 with:
-  app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+  app-id: ${{ vars.CI_APP_ID }}
 secrets:
-  APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+  APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
 Example — PAT caller (existing repos, unchanged):

--- a/.cursor/rules/ci-cd-workflows.mdc
+++ b/.cursor/rules/ci-cd-workflows.mdc
@@ -25,7 +25,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
-| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` |
+| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` or `app-id` + `APP_PRIVATE_KEY` |
 | `claude.yml` | `reusable-claude.yml` | Issue/PR @-mentions | `CLAUDE_CODE_OAUTH_TOKEN` |
 
 ### Release-Please Workflow Inputs
@@ -50,9 +50,9 @@ Example — App-token caller (infrastructure repo):
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
 with:
-  app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+  app-id: ${{ vars.CI_APP_ID }}
 secrets:
-  APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+  APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
 Example — PAT caller (existing repos, unchanged):

--- a/.gemini/memories/ci-cd-workflows.md
+++ b/.gemini/memories/ci-cd-workflows.md
@@ -20,7 +20,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
-| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` |
+| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` or `app-id` + `APP_PRIVATE_KEY` |
 | `claude.yml` | `reusable-claude.yml` | Issue/PR @-mentions | `CLAUDE_CODE_OAUTH_TOKEN` |
 
 ### Release-Please Workflow Inputs
@@ -45,9 +45,9 @@ Example — App-token caller (infrastructure repo):
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
 with:
-  app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+  app-id: ${{ vars.CI_APP_ID }}
 secrets:
-  APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+  APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
 Example — PAT caller (existing repos, unchanged):

--- a/.github/instructions/ci-cd-workflows.instructions.md
+++ b/.github/instructions/ci-cd-workflows.instructions.md
@@ -24,7 +24,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
-| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` |
+| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` or `app-id` + `APP_PRIVATE_KEY` |
 | `claude.yml` | `reusable-claude.yml` | Issue/PR @-mentions | `CLAUDE_CODE_OAUTH_TOKEN` |
 
 ### Release-Please Workflow Inputs
@@ -49,9 +49,9 @@ Example — App-token caller (infrastructure repo):
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
 with:
-  app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+  app-id: ${{ vars.CI_APP_ID }}
 secrets:
-  APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+  APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
 Example — PAT caller (existing repos, unchanged):

--- a/.rulesync/rules/ci-cd-workflows.md
+++ b/.rulesync/rules/ci-cd-workflows.md
@@ -26,7 +26,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
-| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` |
+| `auto-merge-image-updater.yml` | `reusable-auto-merge-image-updater.yml` | `image-updater-**` branches | `AUTO_MERGE_PAT` or `app-id` + `APP_PRIVATE_KEY` |
 | `claude.yml` | `reusable-claude.yml` | Issue/PR @-mentions | `CLAUDE_CODE_OAUTH_TOKEN` |
 
 ### Release-Please Workflow Inputs
@@ -51,9 +51,9 @@ Example — App-token caller (infrastructure repo):
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
 with:
-  app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+  app-id: ${{ vars.CI_APP_ID }}
 secrets:
-  APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+  APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
 Example — PAT caller (existing repos, unchanged):


### PR DESCRIPTION
## Summary

Corrects two stale facts in the `ci-cd-workflows` rulesync rule and regenerates
the tool-specific copies (claudecode / copilot / geminicli / cursor):

- **auto-merge auth** was documented as `AUTO_MERGE_PAT`-only. The
  `reusable-auto-merge-image-updater.yml` workflow also accepts
  `app-id` + `APP_PRIVATE_KEY` (App-token approval, added in #60). Now shown
  alongside the PAT, matching the release-please and renovate rows.
- the release-please App-token example used non-existent
  `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY` vars. The live org
  names are `vars.CI_APP_ID` / `secrets.CI_APP_PRIVATE_KEY` — verified against the
  infrastructure repo's `release-please.yaml` caller and `github/secrets_ci_app.tf`.

Edited the rulesync **source** (`.rulesync/rules/ci-cd-workflows.md`) and ran
`npx rulesync generate` to refresh the four generated copies.

## Pre-merge

- **Best landed after #60** (`feat(auto-merge): support GitHub App token for
  image-updater PR approval`), which is the change that actually introduces the
  `app-id` + `APP_PRIVATE_KEY` auth this PR documents. Merging this first would
  briefly document a capability not yet on `@main`. The `CI_APP_ID` var-name fix
  is independent of #60 and correct regardless.

## Post-merge

- The org reusable-sync-ai-rules workflow propagates the updated rule to consumer
  repos automatically — no manual action required.

## Test plan

- [x] `npx rulesync generate` reproduces only the `ci-cd-workflows` copies with
  these edits (unrelated regen drift excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
