### PR TITLE
feat(renovate): add autodiscover and repositories inputs to reusable-renovate

### DIFF
--- a/.github/workflows/reusable-renovate.yml
+++ b/.github/workflows/reusable-renovate.yml
@@ -38,6 +38,21 @@ on:
         required: false
         type: number
         default: 60
+      repositories:
+        description: 'Explicit RENOVATE_REPOSITORIES value (space- or comma-separated owner/repo slugs). Overrides the default of scanning only the calling repo. Ignored when autodiscover is enabled.'
+        required: false
+        type: string
+        default: ''
+      autodiscover:
+        description: 'Set to true to autodiscover every repository the App installation can access (RENOVATE_AUTODISCOVER), optionally narrowed by autodiscover-filter. Takes precedence over repositories.'
+        required: false
+        type: string
+        default: 'false'
+      autodiscover-filter:
+        description: 'RENOVATE_AUTODISCOVER_FILTER value (e.g. ForumViriumHelsinki/*) scoping autodiscovery. Only applies when autodiscover is true.'
+        required: false
+        type: string
+        default: ''
     secrets:
       APP_PRIVATE_KEY:
         description: 'Renovate App private key. Required iff app-id is set.'
@@ -69,6 +84,24 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Resolve Renovate target repositories
+        env:
+          AUTODISCOVER: ${{ inputs.autodiscover }}
+          AUTODISCOVER_FILTER: ${{ inputs.autodiscover-filter }}
+          REPOSITORIES: ${{ inputs.repositories }}
+          DEFAULT_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$AUTODISCOVER" = "true" ]; then
+            {
+              echo "RENOVATE_AUTODISCOVER=true"
+              echo "RENOVATE_AUTODISCOVER_FILTER=$AUTODISCOVER_FILTER"
+            } >> "$GITHUB_ENV"
+          elif [ -n "$REPOSITORIES" ]; then
+            echo "RENOVATE_REPOSITORIES=$REPOSITORIES" >> "$GITHUB_ENV"
+          else
+            echo "RENOVATE_REPOSITORIES=$DEFAULT_REPOSITORY" >> "$GITHUB_ENV"
+          fi
+
       - uses: renovatebot/github-action@v46.1.0
         with:
           token: ${{ inputs.app-id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -78,5 +111,4 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dry-run != 'false' && inputs.dry-run || '' }}
           RENOVATE_USERNAME: ${{ inputs.bot-username }}
           RENOVATE_GIT_AUTHOR: ${{ inputs.bot-git-author }}
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: "[{\"matchHost\":\"ghcr.io\",\"hostType\":\"docker\",\"username\":\"x-access-token\",\"password\":\"${{ inputs.app-id != '' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}\"}]"


### PR DESCRIPTION
## What

Add three optional inputs to `reusable-renovate.yml` so a central caller can scan repositories beyond the calling repo:

| Input | Default | Effect |
|-------|---------|--------|
| `repositories` | `''` | Explicit `RENOVATE_REPOSITORIES` list (space/comma-separated `owner/repo`). |
| `autodiscover` | `'false'` | When `true`, sets `RENOVATE_AUTODISCOVER=true` (scans every repo the App installation can access). Takes precedence over `repositories`. |
| `autodiscover-filter` | `''` | `RENOVATE_AUTODISCOVER_FILTER` glob (e.g. `ForumViriumHelsinki/*`). Only applies when `autodiscover` is `true`. |

A `Resolve Renovate target repositories` step maps the inputs to env vars via `$GITHUB_ENV`:

- `autodiscover: true` -> `RENOVATE_AUTODISCOVER=true` + filter (no `RENOVATE_REPOSITORIES`)
- else `repositories` set -> `RENOVATE_REPOSITORIES=<list>`
- else -> `RENOVATE_REPOSITORIES=${{ github.repository }}` (**unchanged default** -- existing behaviour preserved)

A dedicated step (rather than an inline `${{ A && B || C }}` ternary) avoids the empty-string-is-falsy trap and keeps inputs out of `run:` interpolation (injection-safe).

## Why

ADR-0036 centralizes Renovate execution in the infrastructure repo, scanning all FVH repos from one caller. That was blocked because `reusable-renovate.yml` hardcoded `RENOVATE_REPOSITORIES: ${{ github.repository }}` -- it only ever scanned the calling repo. ADR-0036 flagged this input as the required follow-up.

## Validation

- `actionlint .github/workflows/reusable-renovate.yml` -> pass
- Default path unchanged: with no new inputs, `RENOVATE_REPOSITORIES` resolves to `${{ github.repository }}` exactly as before.

## Follow-ups

- The Renovate inputs table in `.rulesync/rules/ci-cd-workflows.md` should gain the three new rows (documentation sync; not done here) — tracked in #63.
- The infrastructure caller change (`autodiscover: true`) lands in a separate PR that **depends on this one** merging first, since it references `@main`.

Refs ForumViriumHelsinki/infrastructure#1941 (step 1), ADR-0036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
