### PR TITLE
ci: use Opus 4.8 with medium effort for Claude Code workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,5 +57,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-8 --effort medium'
 

--- a/.github/workflows/reusable-auto-fix.yml
+++ b/.github/workflows/reusable-auto-fix.yml
@@ -90,10 +90,10 @@ on:
           - Issues requiring secrets or credentials changes
           - Failures in workflows not related to code changes on this branch
       claude_args:
-        description: 'Additional arguments for Claude Code (e.g., "--model sonnet --max-turns 30")'
+        description: 'Additional arguments for Claude Code (e.g., "--model claude-opus-4-8 --effort medium --max-turns 30")'
         required: false
         type: string
-        default: '--model sonnet --max-turns 30'
+        default: '--model claude-opus-4-8 --effort medium --max-turns 30'
       additional_permissions:
         description: 'Additional tool permissions for Claude Code'
         required: false

--- a/.github/workflows/reusable-claude-review.yml
+++ b/.github/workflows/reusable-claude-review.yml
@@ -42,7 +42,7 @@ on:
         description: 'Additional arguments for Claude Code'
         required: false
         type: string
-        default: '--max-turns 20'
+        default: '--model claude-opus-4-8 --effort medium --max-turns 20'
       additional_permissions:
         description: 'Additional tool permissions for Claude Code'
         required: false

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
+            --model claude-opus-4-8 --effort medium
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "${{ inputs.allowed_tools }}"
             --system-prompt "You have a limited turn budget of ${{ inputs.max_turns }} turns in CI.


### PR DESCRIPTION
## Summary

Switches the Claude Code action workflows from Sonnet to **`claude-opus-4-8` with `--effort medium`**.

Previously:
- `reusable-auto-fix.yml` explicitly defaulted to `--model sonnet`
- `reusable-claude.yml`, `reusable-claude-review.yml`, and the org's own `claude.yml` set no `--model`, so the action fell back to its Sonnet default

## Changes

| Workflow | Change |
|----------|--------|
| `reusable-claude.yml` | Prepend `--model claude-opus-4-8 --effort medium` to `claude_args` |
| `reusable-claude-review.yml` | Add `--model claude-opus-4-8 --effort medium` to the default `claude_args` |
| `reusable-auto-fix.yml` | Replace `--model sonnet` default (and the description example) with `--model claude-opus-4-8 --effort medium` |
| `claude.yml` | Set `claude_args: '--model claude-opus-4-8 --effort medium'` on the org's own `@claude` handler |

The `--model claude-opus-4-8 --effort medium` flags forward through `claude_args` to the Claude Code CLI (`--effort` accepts `low`/`medium`/`high`/`xhigh`/`max`).

## Out of scope

The security / quality / a11y scan workflows (`reusable-security-*`, `reusable-quality-*`, `reusable-a11y-*`) and `reusable-auto-resolve-conflicts.yml` intentionally remain on **haiku** — they are narrow, cost-sensitive scans, not Sonnet, so they were left unchanged.

## Testing

- `python yaml.safe_load` passes on all four edited files
- actionlint not available in this environment (skipped)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTtQjtPGcqy85ke95CsikS)_