### PR TITLE
docs(rules): rename Theme Management project routing to Thelma

### DIFF
--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -47,7 +47,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
 | 5 | TFDS | `project:tfds` | TFDS application and related services |
-| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 6 | Thelma | `project:thelma` | Theme, UI, design system work |
 | 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -48,7 +48,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
 | 5 | TFDS | `project:tfds` | TFDS application and related services |
-| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 6 | Thelma | `project:thelma` | Theme, UI, design system work |
 | 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -43,7 +43,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
 | 5 | TFDS | `project:tfds` | TFDS application and related services |
-| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 6 | Thelma | `project:thelma` | Theme, UI, design system work |
 | 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -49,7 +49,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
 | 5 | TFDS | `project:tfds` | TFDS application and related services |
-| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 6 | Thelma | `project:thelma` | Theme, UI, design system work |
 | 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |

--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -49,7 +49,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
 | 5 | TFDS | `project:tfds` | TFDS application and related services |
-| 6 | Theme Management | `project:theme-management` | Theme, UI, design system work |
+| 6 | Thelma | `project:thelma` | Theme, UI, design system work |
 | 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |


### PR DESCRIPTION
## What

Renames the project-routing entry **Theme Management / `project:theme-management`** → **Thelma / `project:thelma`** in the canonical rulesync source (`.rulesync/rules/github-metadata-hygiene.md`) and its four generated copies (Claude, Cursor, Gemini, Copilot instructions) so app repos pick it up on the next AI-rules sync.

## Why

The theme-management repo and GitHub Project board #6 were renamed to Thelma. The label itself is renamed in Terraform via ForumViriumHelsinki/infrastructure#2014; post-apply follow-ups are tracked in ForumViriumHelsinki/infrastructure#2013.

All five files changed with the same mechanical substitution (`project:theme-management` → `project:thelma`, `Theme Management` → `Thelma`), equivalent to re-running `rulesync generate` on the updated source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)