### PR TITLE
docs: make GitHub App the default release-please auth

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -20,7 +20,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 
 | Caller Workflow | Reusable Workflow | Trigger | Auth |
 |----------------|-------------------|---------|------|
-| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `MY_RELEASE_PLEASE_TOKEN` (PAT) or `app-id` + `APP_PRIVATE_KEY` |
+| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `app-id` + `APP_PRIVATE_KEY` (preferred) or `MY_RELEASE_PLEASE_TOKEN` (PAT, legacy) |
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
@@ -35,16 +35,16 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 |-------|------|---------|-------------|
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
-| `app-id` | string | `''` | GitHub App ID; when set, uses an App token instead of `MY_RELEASE_PLEASE_TOKEN` |
+| `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
 | `runner` | string | `ubuntu-latest` | Runner label |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 
 Secrets:
-- `MY_RELEASE_PLEASE_TOKEN` — PAT with `contents:write` and `pull-requests:write` scopes. Required when `app-id` is empty.
-- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set.
+- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set. **Preferred — this is the org standard.**
+- `MY_RELEASE_PLEASE_TOKEN` — legacy PAT with `contents:write` and `pull-requests:write` scopes. Used only when `app-id` is empty. The shared org PAT expired 2026-06; new and migrated repos must use the App token.
 
-Example — App-token caller (infrastructure repo):
+Example — App-token caller (recommended; default for all repos):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
@@ -54,7 +54,7 @@ secrets:
   APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
-Example — PAT caller (existing repos, unchanged):
+Example — PAT caller (legacy; the shared org PAT expired 2026-06 — migrate to the App token above):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main

--- a/.cursor/rules/ci-cd-workflows.mdc
+++ b/.cursor/rules/ci-cd-workflows.mdc
@@ -21,7 +21,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 
 | Caller Workflow | Reusable Workflow | Trigger | Auth |
 |----------------|-------------------|---------|------|
-| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `MY_RELEASE_PLEASE_TOKEN` (PAT) or `app-id` + `APP_PRIVATE_KEY` |
+| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `app-id` + `APP_PRIVATE_KEY` (preferred) or `MY_RELEASE_PLEASE_TOKEN` (PAT, legacy) |
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
@@ -36,16 +36,16 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 |-------|------|---------|-------------|
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
-| `app-id` | string | `''` | GitHub App ID; when set, uses an App token instead of `MY_RELEASE_PLEASE_TOKEN` |
+| `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
 | `runner` | string | `ubuntu-latest` | Runner label |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 
 Secrets:
-- `MY_RELEASE_PLEASE_TOKEN` — PAT with `contents:write` and `pull-requests:write` scopes. Required when `app-id` is empty.
-- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set.
+- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set. **Preferred — this is the org standard.**
+- `MY_RELEASE_PLEASE_TOKEN` — legacy PAT with `contents:write` and `pull-requests:write` scopes. Used only when `app-id` is empty. The shared org PAT expired 2026-06; new and migrated repos must use the App token.
 
-Example — App-token caller (infrastructure repo):
+Example — App-token caller (recommended; default for all repos):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
@@ -55,7 +55,7 @@ secrets:
   APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
-Example — PAT caller (existing repos, unchanged):
+Example — PAT caller (legacy; the shared org PAT expired 2026-06 — migrate to the App token above):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main

--- a/.gemini/memories/ci-cd-workflows.md
+++ b/.gemini/memories/ci-cd-workflows.md
@@ -16,7 +16,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 
 | Caller Workflow | Reusable Workflow | Trigger | Auth |
 |----------------|-------------------|---------|------|
-| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `MY_RELEASE_PLEASE_TOKEN` (PAT) or `app-id` + `APP_PRIVATE_KEY` |
+| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `app-id` + `APP_PRIVATE_KEY` (preferred) or `MY_RELEASE_PLEASE_TOKEN` (PAT, legacy) |
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
@@ -31,16 +31,16 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 |-------|------|---------|-------------|
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
-| `app-id` | string | `''` | GitHub App ID; when set, uses an App token instead of `MY_RELEASE_PLEASE_TOKEN` |
+| `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
 | `runner` | string | `ubuntu-latest` | Runner label |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 
 Secrets:
-- `MY_RELEASE_PLEASE_TOKEN` — PAT with `contents:write` and `pull-requests:write` scopes. Required when `app-id` is empty.
-- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set.
+- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set. **Preferred — this is the org standard.**
+- `MY_RELEASE_PLEASE_TOKEN` — legacy PAT with `contents:write` and `pull-requests:write` scopes. Used only when `app-id` is empty. The shared org PAT expired 2026-06; new and migrated repos must use the App token.
 
-Example — App-token caller (infrastructure repo):
+Example — App-token caller (recommended; default for all repos):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
@@ -50,7 +50,7 @@ secrets:
   APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
-Example — PAT caller (existing repos, unchanged):
+Example — PAT caller (legacy; the shared org PAT expired 2026-06 — migrate to the App token above):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main

--- a/.github/instructions/ci-cd-workflows.instructions.md
+++ b/.github/instructions/ci-cd-workflows.instructions.md
@@ -20,7 +20,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 
 | Caller Workflow | Reusable Workflow | Trigger | Auth |
 |----------------|-------------------|---------|------|
-| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `MY_RELEASE_PLEASE_TOKEN` (PAT) or `app-id` + `APP_PRIVATE_KEY` |
+| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `app-id` + `APP_PRIVATE_KEY` (preferred) or `MY_RELEASE_PLEASE_TOKEN` (PAT, legacy) |
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
@@ -35,16 +35,16 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 |-------|------|---------|-------------|
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
-| `app-id` | string | `''` | GitHub App ID; when set, uses an App token instead of `MY_RELEASE_PLEASE_TOKEN` |
+| `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
 | `runner` | string | `ubuntu-latest` | Runner label |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 
 Secrets:
-- `MY_RELEASE_PLEASE_TOKEN` — PAT with `contents:write` and `pull-requests:write` scopes. Required when `app-id` is empty.
-- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set.
+- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set. **Preferred — this is the org standard.**
+- `MY_RELEASE_PLEASE_TOKEN` — legacy PAT with `contents:write` and `pull-requests:write` scopes. Used only when `app-id` is empty. The shared org PAT expired 2026-06; new and migrated repos must use the App token.
 
-Example — App-token caller (infrastructure repo):
+Example — App-token caller (recommended; default for all repos):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
@@ -54,7 +54,7 @@ secrets:
   APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
-Example — PAT caller (existing repos, unchanged):
+Example — PAT caller (legacy; the shared org PAT expired 2026-06 — migrate to the App token above):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main

--- a/.rulesync/rules/ci-cd-workflows.md
+++ b/.rulesync/rules/ci-cd-workflows.md
@@ -22,7 +22,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 
 | Caller Workflow | Reusable Workflow | Trigger | Auth |
 |----------------|-------------------|---------|------|
-| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `MY_RELEASE_PLEASE_TOKEN` (PAT) or `app-id` + `APP_PRIVATE_KEY` |
+| `release-please.yml` | `reusable-release-please.yml` | Push to `main` | `app-id` + `APP_PRIVATE_KEY` (preferred) or `MY_RELEASE_PLEASE_TOKEN` (PAT, legacy) |
 | `renovate.yml` | `reusable-renovate.yml` | Schedule | `GITHUB_TOKEN` or `app-id` + `APP_PRIVATE_KEY` |
 | `container-build.yml` | `reusable-container-build.yml` | release-please PR (PR phase) | — |
 | `container-release.yml` | `reusable-container-release.yml` | Published release (release phase) | — |
@@ -37,16 +37,16 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 |-------|------|---------|-------------|
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
-| `app-id` | string | `''` | GitHub App ID; when set, uses an App token instead of `MY_RELEASE_PLEASE_TOKEN` |
+| `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
 | `runner` | string | `ubuntu-latest` | Runner label |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 
 Secrets:
-- `MY_RELEASE_PLEASE_TOKEN` — PAT with `contents:write` and `pull-requests:write` scopes. Required when `app-id` is empty.
-- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set.
+- `APP_PRIVATE_KEY` — GitHub App private key. Required when `app-id` is set. **Preferred — this is the org standard.**
+- `MY_RELEASE_PLEASE_TOKEN` — legacy PAT with `contents:write` and `pull-requests:write` scopes. Used only when `app-id` is empty. The shared org PAT expired 2026-06; new and migrated repos must use the App token.
 
-Example — App-token caller (infrastructure repo):
+Example — App-token caller (recommended; default for all repos):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
@@ -56,7 +56,7 @@ secrets:
   APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 ```
 
-Example — PAT caller (existing repos, unchanged):
+Example — PAT caller (legacy; the shared org PAT expired 2026-06 — migrate to the App token above):
 
 ```yaml
 uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main

--- a/workflow-templates/auto-fix.yml
+++ b/workflow-templates/auto-fix.yml
@@ -35,4 +35,7 @@ jobs:
       #   - Type errors with obvious fixes
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # Optional elevated token so auto-fix commits can trigger downstream
+      # workflows. The legacy MY_RELEASE_PLEASE_TOKEN PAT expired 2026-06 —
+      # provision a GitHub App token (CI_APP_ID + CI_APP_PRIVATE_KEY) instead.
       # PAT_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}

--- a/workflow-templates/fvh-app.yml
+++ b/workflow-templates/fvh-app.yml
@@ -35,8 +35,10 @@ jobs:
   release-please:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
+    with:
+      app-id: ${{ vars.CI_APP_ID }}
     secrets:
-      RELEASE_PLEASE_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
   # Auto-merge ArgoCD Image Updater PRs.
   # Single-job design: creates PR, approves, and enables auto-merge in one run


### PR DESCRIPTION
## Why

The shared org PAT `MY_RELEASE_PLEASE_TOKEN` expired, breaking release-please across all PAT-based repos. The org is migrating to the GitHub App token (`CI_APP_ID` + `CI_APP_PRIVATE_KEY`). This updates the **scaffold + guidance** so new repos don't inherit the broken PAT pattern.

## Changes

- `workflow-templates/fvh-app.yml`: release-please job now uses the App token (`app-id` + `APP_PRIVATE_KEY`). Also fixes a latent bug — it passed a `RELEASE_PLEASE_TOKEN` secret, but the reusable workflow only declares `MY_RELEASE_PLEASE_TOKEN`, so the mapping never reached the expected secret.
- `ci-cd-workflows` rule (rulesync source + 4 generated copies): App token framed as **preferred/default**; PAT documented as expired-legacy. Generated copies edited in lockstep with the source; `npx rulesync generate` should produce no further diff.

Part of the org-wide PAT→App release-please migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)