### PR TITLE
fix(security-deps): use bun audit for bun projects

### DIFF
--- a/.github/workflows/reusable-security-deps.yml
+++ b/.github/workflows/reusable-security-deps.yml
@@ -102,8 +102,9 @@ jobs:
               npm audit --json > audit-results.json 2>&1 || true
               ;;
             bun)
-              # Bun doesn't have built-in audit, use npm
-              npm audit --json > audit-results.json 2>&1 || true
+              # bun audit reads bun.lock natively (Bun >=1.2.15); no install needed.
+              # npm audit ENOLOCKs here since the repo has no package-lock.json.
+              bun audit --json > audit-results.json 2>&1 || true
               ;;
             pnpm)
               pnpm audit --json > audit-results.json 2>&1 || true


### PR DESCRIPTION
## Problem

The `deps / audit` check (`reusable-security-deps.yml`) **fails on every PR** for Bun repos — including release-please PRs that only touch CHANGELOG/version and cannot introduce a vulnerability. Observed in silverbucket-helper PRs #359 and #334.

Root cause: the `bun` case in the audit step ran `npm audit --json`, with the outdated comment *"Bun doesn't have built-in audit, use npm"*. `npm audit` requires a `package-lock.json`, which Bun repos don't have, so it errors:

```
npm error code ENOLOCK
npm error audit This command requires an existing lockfile.
```

That error blob is then fed to the `Claude Dependency Analysis` step, which is the step that actually concludes `failure` (~18s).

## Fix

Run `bun audit --json` for the `bun` case. Bun added a built-in audit in **1.2.15**; it reads `bun.lock` natively and needs no `bun install` step.

Verified locally against silverbucket-helper's `bun.lock` (no install): emits valid advisory JSON (a moderate `brace-expansion` DoS) and exits 1 on findings. The existing `|| true` + `continue-on-error: true` absorb the exit code, so report-don't-block behavior (`fail-on-high` default `false`) is preserved.

## Impact

Unblocks the `deps / audit` check across all Bun repos in the org. After merge, re-run the check on the affected PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)