### PR TITLE
fix(security-deps): allow bot-authored PRs to run the audit

### DIFF
--- a/.github/workflows/reusable-security-deps.yml
+++ b/.github/workflows/reusable-security-deps.yml
@@ -135,6 +135,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          # Dependency PRs are bot-authored (Renovate, release-please). On a
+          # re-run GitHub replays the original pull_request event whose sender
+          # is the bot, so the action's human-actor guard blocks it without
+          # this. Audit-and-comment is read-only with a fixed prompt — safe.
+          allowed_bots: "*"
           prompt: |
             Analyze the dependency security audit results for this project.
 


### PR DESCRIPTION
## Problem

After #75 fixed the `bun audit` command, the `deps / audit` check still fails on bot-authored PRs (release-please, Renovate) — including silverbucket-helper #359 — with:

```
Error: Workflow initiated by non-human actor: forumviriumhelsinki-ci (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action` guards against bot-triggered runs. On a **check re-run**, GitHub replays the original `pull_request` event whose `sender` is the bot that opened the PR, so the guard fires no matter who clicks re-run.

The other Claude-powered reusable workflows (owasp, typescript, a11y) avoid this only incidentally — they `if:`-skip the Claude step when no relevant files changed, so on a code-free release PR they never invoke the action. `reusable-security-deps.yml` runs its audit unconditionally, so it alone hits the guard.

## Fix

Set `allowed_bots: "*"` on the audit's claude-code-action step — mirroring `reusable-auto-fix.yml` and `reusable-claude-review.yml`, which already set `allowed_bots`. The step is a read-only, fixed-prompt audit-and-comment with scoped permissions (contents:read, pull-requests:write); dependency PRs (Renovate) are precisely where the audit is most valuable, so enabling bot runs is intended, not just a workaround.

## After merge

Re-run `deps / audit` on silverbucket-helper #359 (and any open Renovate PRs); the `@main` pin picks this up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)