### PR TITLE
docs(rules): add pre-commit config-gotchas rule, regen stale outputs

### DIFF
--- a/.claude/rules/github-metadata-hygiene.md
+++ b/.claude/rules/github-metadata-hygiene.md
@@ -52,6 +52,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, cost attribution, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 

--- a/.claude/rules/local-development.md
+++ b/.claude/rules/local-development.md
@@ -11,12 +11,12 @@ paths:
 
 Applications use Skaffold for local Kubernetes development with common profiles:
 
-| Profile | Purpose |
-|---------|---------|
-| `dev` | Full stack (all services + databases) |
-| `db-only` | Database only (for running app server locally) |
-| `services-only` | Infrastructure services without the main app |
-| `frontend-only` | Frontend dev server with hot reload |
+| Profile         | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `dev`           | Full stack (all services + databases)          |
+| `db-only`       | Database only (for running app server locally) |
+| `services-only` | Infrastructure services without the main app   |
+| `frontend-only` | Frontend dev server with hot reload            |
 
 Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm-webapp` from GHCR.
 
@@ -29,25 +29,25 @@ Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm
 
 Application justfiles should organize recipes into these groups:
 
-| Group | Recipes |
-|-------|---------|
-| dev | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
-| test | `test`, `test-watch`, `test-coverage` |
-| lint | `lint`, `format`, `typecheck` |
-| build | `build`, `docker-build` |
-| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell` |
+| Group    | Recipes                                          |
+| -------- | ------------------------------------------------ |
+| dev      | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
+| test     | `test`, `test-watch`, `test-coverage`            |
+| lint     | `lint`, `format`, `typecheck`                    |
+| build    | `build`, `docker-build`                          |
+| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell`  |
 
 ## Pre-commit Hooks
 
 Common hooks across FVH application repos:
 
-| Hook | Purpose |
-|------|---------|
-| `commitizen` | Enforce conventional commit messages |
-| `biome` / `ruff` | Language-specific linting and formatting |
-| `detect-secrets` | Prevent accidental secret commits |
-| `check-yaml` / `trailing-whitespace` | General file hygiene |
-| `helm-lint` | Validate Helm values (if `deploy/` exists) |
+| Hook                                 | Purpose                                    |
+| ------------------------------------ | ------------------------------------------ |
+| `commitizen`                         | Enforce conventional commit messages       |
+| `biome` / `ruff`                     | Language-specific linting and formatting   |
+| `detect-secrets`                     | Prevent accidental secret commits          |
+| `check-yaml` / `trailing-whitespace` | General file hygiene                       |
+| `helm-lint`                          | Validate Helm values (if `deploy/` exists) |
 
 Install and run:
 
@@ -56,13 +56,28 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Pre-commit Config Gotchas
+
+A red `pre-commit` / "Code Quality" CI job often traces to the hook _config_,
+not the code. These three hit FVH app repos and are config fixes, not file edits:
+
+| Symptom                                                                   | Root cause                                                                                                                                                                                                        | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| biome: `Found a nested root configuration`                                | A subdir config (e.g. `react_ui/biome.json`) run with `--config-path` from the repo root is treated as a second root config under biome 2.x                                                                       | Add `"root": false` to the nested config **and** drop `--config-path` from the hook `entry` so biome auto-discovers per file (the two are mutually exclusive — `--config-path` requires a root config) |
+| yamllint: `wrong indentation: expected N but found N-2` on every sequence | Helm/k8s values align block sequences with their parent key; the default `indent-sequences: true` rejects that style                                                                                              | Set `indentation: {indent-sequences: consistent}` in `.yamllint` — workflows indent, values don't; both stay internally consistent                                                                     |
+| check-yaml: `Failed` on a `deploy/*values.yaml`                           | A **duplicate top-level key** (ruamel rejects dup keys). YAML last-wins silently dropped the first block — e.g. a second `migrations:` overriding the first's `migrations.image` that ArgoCD Image Updater tracks | Merge the duplicated key's blocks into one, preserving the path Image Updater writes to (`migrations.image.tag`)                                                                                       |
+
+When the fix is on the hook config, also bump any `additional_dependencies`
+version pin to match the config's `$schema` (e.g. biome `2.3.14`), and verify
+with `pre-commit run <hook-id> --all-files` before pushing.
+
 ## Local ↔ CI Parity
 
 **Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
 
 Concrete patterns that help:
 
-- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- A `just lint` / `just test` recipe that invokes the _same_ command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
 - Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
 - When CI adds a new check, update the matching local recipe in the same PR.
 

--- a/.cursor/rules/github-metadata-hygiene.mdc
+++ b/.cursor/rules/github-metadata-hygiene.mdc
@@ -53,6 +53,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, cost attribution, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 

--- a/.cursor/rules/local-development.mdc
+++ b/.cursor/rules/local-development.mdc
@@ -9,12 +9,12 @@ globs: **/skaffold.yaml,**/justfile,**/k8s/**,**/.pre-commit-config.yaml
 
 Applications use Skaffold for local Kubernetes development with common profiles:
 
-| Profile | Purpose |
-|---------|---------|
-| `dev` | Full stack (all services + databases) |
-| `db-only` | Database only (for running app server locally) |
-| `services-only` | Infrastructure services without the main app |
-| `frontend-only` | Frontend dev server with hot reload |
+| Profile         | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `dev`           | Full stack (all services + databases)          |
+| `db-only`       | Database only (for running app server locally) |
+| `services-only` | Infrastructure services without the main app   |
+| `frontend-only` | Frontend dev server with hot reload            |
 
 Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm-webapp` from GHCR.
 
@@ -27,25 +27,25 @@ Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm
 
 Application justfiles should organize recipes into these groups:
 
-| Group | Recipes |
-|-------|---------|
-| dev | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
-| test | `test`, `test-watch`, `test-coverage` |
-| lint | `lint`, `format`, `typecheck` |
-| build | `build`, `docker-build` |
-| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell` |
+| Group    | Recipes                                          |
+| -------- | ------------------------------------------------ |
+| dev      | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
+| test     | `test`, `test-watch`, `test-coverage`            |
+| lint     | `lint`, `format`, `typecheck`                    |
+| build    | `build`, `docker-build`                          |
+| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell`  |
 
 ## Pre-commit Hooks
 
 Common hooks across FVH application repos:
 
-| Hook | Purpose |
-|------|---------|
-| `commitizen` | Enforce conventional commit messages |
-| `biome` / `ruff` | Language-specific linting and formatting |
-| `detect-secrets` | Prevent accidental secret commits |
-| `check-yaml` / `trailing-whitespace` | General file hygiene |
-| `helm-lint` | Validate Helm values (if `deploy/` exists) |
+| Hook                                 | Purpose                                    |
+| ------------------------------------ | ------------------------------------------ |
+| `commitizen`                         | Enforce conventional commit messages       |
+| `biome` / `ruff`                     | Language-specific linting and formatting   |
+| `detect-secrets`                     | Prevent accidental secret commits          |
+| `check-yaml` / `trailing-whitespace` | General file hygiene                       |
+| `helm-lint`                          | Validate Helm values (if `deploy/` exists) |
 
 Install and run:
 
@@ -54,13 +54,28 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Pre-commit Config Gotchas
+
+A red `pre-commit` / "Code Quality" CI job often traces to the hook _config_,
+not the code. These three hit FVH app repos and are config fixes, not file edits:
+
+| Symptom                                                                   | Root cause                                                                                                                                                                                                        | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| biome: `Found a nested root configuration`                                | A subdir config (e.g. `react_ui/biome.json`) run with `--config-path` from the repo root is treated as a second root config under biome 2.x                                                                       | Add `"root": false` to the nested config **and** drop `--config-path` from the hook `entry` so biome auto-discovers per file (the two are mutually exclusive — `--config-path` requires a root config) |
+| yamllint: `wrong indentation: expected N but found N-2` on every sequence | Helm/k8s values align block sequences with their parent key; the default `indent-sequences: true` rejects that style                                                                                              | Set `indentation: {indent-sequences: consistent}` in `.yamllint` — workflows indent, values don't; both stay internally consistent                                                                     |
+| check-yaml: `Failed` on a `deploy/*values.yaml`                           | A **duplicate top-level key** (ruamel rejects dup keys). YAML last-wins silently dropped the first block — e.g. a second `migrations:` overriding the first's `migrations.image` that ArgoCD Image Updater tracks | Merge the duplicated key's blocks into one, preserving the path Image Updater writes to (`migrations.image.tag`)                                                                                       |
+
+When the fix is on the hook config, also bump any `additional_dependencies`
+version pin to match the config's `$schema` (e.g. biome `2.3.14`), and verify
+with `pre-commit run <hook-id> --all-files` before pushing.
+
 ## Local ↔ CI Parity
 
 **Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
 
 Concrete patterns that help:
 
-- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- A `just lint` / `just test` recipe that invokes the _same_ command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
 - Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
 - When CI adds a new check, update the matching local recipe in the same PR.
 

--- a/.gemini/memories/github-metadata-hygiene.md
+++ b/.gemini/memories/github-metadata-hygiene.md
@@ -48,6 +48,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, cost attribution, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 

--- a/.gemini/memories/local-development.md
+++ b/.gemini/memories/local-development.md
@@ -4,12 +4,12 @@
 
 Applications use Skaffold for local Kubernetes development with common profiles:
 
-| Profile | Purpose |
-|---------|---------|
-| `dev` | Full stack (all services + databases) |
-| `db-only` | Database only (for running app server locally) |
-| `services-only` | Infrastructure services without the main app |
-| `frontend-only` | Frontend dev server with hot reload |
+| Profile         | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `dev`           | Full stack (all services + databases)          |
+| `db-only`       | Database only (for running app server locally) |
+| `services-only` | Infrastructure services without the main app   |
+| `frontend-only` | Frontend dev server with hot reload            |
 
 Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm-webapp` from GHCR.
 
@@ -22,25 +22,25 @@ Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm
 
 Application justfiles should organize recipes into these groups:
 
-| Group | Recipes |
-|-------|---------|
-| dev | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
-| test | `test`, `test-watch`, `test-coverage` |
-| lint | `lint`, `format`, `typecheck` |
-| build | `build`, `docker-build` |
-| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell` |
+| Group    | Recipes                                          |
+| -------- | ------------------------------------------------ |
+| dev      | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
+| test     | `test`, `test-watch`, `test-coverage`            |
+| lint     | `lint`, `format`, `typecheck`                    |
+| build    | `build`, `docker-build`                          |
+| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell`  |
 
 ## Pre-commit Hooks
 
 Common hooks across FVH application repos:
 
-| Hook | Purpose |
-|------|---------|
-| `commitizen` | Enforce conventional commit messages |
-| `biome` / `ruff` | Language-specific linting and formatting |
-| `detect-secrets` | Prevent accidental secret commits |
-| `check-yaml` / `trailing-whitespace` | General file hygiene |
-| `helm-lint` | Validate Helm values (if `deploy/` exists) |
+| Hook                                 | Purpose                                    |
+| ------------------------------------ | ------------------------------------------ |
+| `commitizen`                         | Enforce conventional commit messages       |
+| `biome` / `ruff`                     | Language-specific linting and formatting   |
+| `detect-secrets`                     | Prevent accidental secret commits          |
+| `check-yaml` / `trailing-whitespace` | General file hygiene                       |
+| `helm-lint`                          | Validate Helm values (if `deploy/` exists) |
 
 Install and run:
 
@@ -49,13 +49,28 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Pre-commit Config Gotchas
+
+A red `pre-commit` / "Code Quality" CI job often traces to the hook _config_,
+not the code. These three hit FVH app repos and are config fixes, not file edits:
+
+| Symptom                                                                   | Root cause                                                                                                                                                                                                        | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| biome: `Found a nested root configuration`                                | A subdir config (e.g. `react_ui/biome.json`) run with `--config-path` from the repo root is treated as a second root config under biome 2.x                                                                       | Add `"root": false` to the nested config **and** drop `--config-path` from the hook `entry` so biome auto-discovers per file (the two are mutually exclusive — `--config-path` requires a root config) |
+| yamllint: `wrong indentation: expected N but found N-2` on every sequence | Helm/k8s values align block sequences with their parent key; the default `indent-sequences: true` rejects that style                                                                                              | Set `indentation: {indent-sequences: consistent}` in `.yamllint` — workflows indent, values don't; both stay internally consistent                                                                     |
+| check-yaml: `Failed` on a `deploy/*values.yaml`                           | A **duplicate top-level key** (ruamel rejects dup keys). YAML last-wins silently dropped the first block — e.g. a second `migrations:` overriding the first's `migrations.image` that ArgoCD Image Updater tracks | Merge the duplicated key's blocks into one, preserving the path Image Updater writes to (`migrations.image.tag`)                                                                                       |
+
+When the fix is on the hook config, also bump any `additional_dependencies`
+version pin to match the config's `$schema` (e.g. biome `2.3.14`), and verify
+with `pre-commit run <hook-id> --all-files` before pushing.
+
 ## Local ↔ CI Parity
 
 **Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
 
 Concrete patterns that help:
 
-- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- A `just lint` / `just test` recipe that invokes the _same_ command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
 - Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
 - When CI adds a new check, update the matching local recipe in the same PR.
 

--- a/.github/instructions/github-metadata-hygiene.instructions.md
+++ b/.github/instructions/github-metadata-hygiene.instructions.md
@@ -54,6 +54,7 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |
+| 11 | Cost Attribution Tooling | `project:cost-attribution` | `fvh-cost-attribution` repo, cost attribution, monthly cost reports, FinOps tooling |
 
 If context doesn't clearly map to one project, ask the user before proceeding.
 

--- a/.github/instructions/local-development.instructions.md
+++ b/.github/instructions/local-development.instructions.md
@@ -8,12 +8,12 @@ applyTo: '**/skaffold.yaml,**/justfile,**/k8s/**,**/.pre-commit-config.yaml'
 
 Applications use Skaffold for local Kubernetes development with common profiles:
 
-| Profile | Purpose |
-|---------|---------|
-| `dev` | Full stack (all services + databases) |
-| `db-only` | Database only (for running app server locally) |
-| `services-only` | Infrastructure services without the main app |
-| `frontend-only` | Frontend dev server with hot reload |
+| Profile         | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `dev`           | Full stack (all services + databases)          |
+| `db-only`       | Database only (for running app server locally) |
+| `services-only` | Infrastructure services without the main app   |
+| `frontend-only` | Frontend dev server with hot reload            |
 
 Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm-webapp` from GHCR.
 
@@ -26,25 +26,25 @@ Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm
 
 Application justfiles should organize recipes into these groups:
 
-| Group | Recipes |
-|-------|---------|
-| dev | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
-| test | `test`, `test-watch`, `test-coverage` |
-| lint | `lint`, `format`, `typecheck` |
-| build | `build`, `docker-build` |
-| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell` |
+| Group    | Recipes                                          |
+| -------- | ------------------------------------------------ |
+| dev      | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
+| test     | `test`, `test-watch`, `test-coverage`            |
+| lint     | `lint`, `format`, `typecheck`                    |
+| build    | `build`, `docker-build`                          |
+| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell`  |
 
 ## Pre-commit Hooks
 
 Common hooks across FVH application repos:
 
-| Hook | Purpose |
-|------|---------|
-| `commitizen` | Enforce conventional commit messages |
-| `biome` / `ruff` | Language-specific linting and formatting |
-| `detect-secrets` | Prevent accidental secret commits |
-| `check-yaml` / `trailing-whitespace` | General file hygiene |
-| `helm-lint` | Validate Helm values (if `deploy/` exists) |
+| Hook                                 | Purpose                                    |
+| ------------------------------------ | ------------------------------------------ |
+| `commitizen`                         | Enforce conventional commit messages       |
+| `biome` / `ruff`                     | Language-specific linting and formatting   |
+| `detect-secrets`                     | Prevent accidental secret commits          |
+| `check-yaml` / `trailing-whitespace` | General file hygiene                       |
+| `helm-lint`                          | Validate Helm values (if `deploy/` exists) |
 
 Install and run:
 
@@ -53,13 +53,28 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Pre-commit Config Gotchas
+
+A red `pre-commit` / "Code Quality" CI job often traces to the hook _config_,
+not the code. These three hit FVH app repos and are config fixes, not file edits:
+
+| Symptom                                                                   | Root cause                                                                                                                                                                                                        | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| biome: `Found a nested root configuration`                                | A subdir config (e.g. `react_ui/biome.json`) run with `--config-path` from the repo root is treated as a second root config under biome 2.x                                                                       | Add `"root": false` to the nested config **and** drop `--config-path` from the hook `entry` so biome auto-discovers per file (the two are mutually exclusive — `--config-path` requires a root config) |
+| yamllint: `wrong indentation: expected N but found N-2` on every sequence | Helm/k8s values align block sequences with their parent key; the default `indent-sequences: true` rejects that style                                                                                              | Set `indentation: {indent-sequences: consistent}` in `.yamllint` — workflows indent, values don't; both stay internally consistent                                                                     |
+| check-yaml: `Failed` on a `deploy/*values.yaml`                           | A **duplicate top-level key** (ruamel rejects dup keys). YAML last-wins silently dropped the first block — e.g. a second `migrations:` overriding the first's `migrations.image` that ArgoCD Image Updater tracks | Merge the duplicated key's blocks into one, preserving the path Image Updater writes to (`migrations.image.tag`)                                                                                       |
+
+When the fix is on the hook config, also bump any `additional_dependencies`
+version pin to match the config's `$schema` (e.g. biome `2.3.14`), and verify
+with `pre-commit run <hook-id> --all-files` before pushing.
+
 ## Local ↔ CI Parity
 
 **Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
 
 Concrete patterns that help:
 
-- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- A `just lint` / `just test` recipe that invokes the _same_ command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
 - Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
 - When CI adds a new check, update the matching local recipe in the same PR.
 

--- a/.rulesync/rules/local-development.md
+++ b/.rulesync/rules/local-development.md
@@ -2,20 +2,22 @@
 root: false
 targets: ["claudecode", "copilot", "geminicli", "cursor"]
 description: "Local dev patterns — Skaffold profiles, justfile recipes, pre-commit hooks"
-globs: ["**/skaffold.yaml", "**/justfile", "**/k8s/**", "**/.pre-commit-config.yaml"]
+globs:
+  ["**/skaffold.yaml", "**/justfile", "**/k8s/**", "**/.pre-commit-config.yaml"]
 ---
+
 # Local Development Patterns
 
 ## Skaffold Profiles
 
 Applications use Skaffold for local Kubernetes development with common profiles:
 
-| Profile | Purpose |
-|---------|---------|
-| `dev` | Full stack (all services + databases) |
-| `db-only` | Database only (for running app server locally) |
-| `services-only` | Infrastructure services without the main app |
-| `frontend-only` | Frontend dev server with hot reload |
+| Profile         | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `dev`           | Full stack (all services + databases)          |
+| `db-only`       | Database only (for running app server locally) |
+| `services-only` | Infrastructure services without the main app   |
+| `frontend-only` | Frontend dev server with hot reload            |
 
 Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm-webapp` from GHCR.
 
@@ -28,25 +30,25 @@ Local dev uses plain K8s manifests in `k8s/` — not Helm. Production uses `helm
 
 Application justfiles should organize recipes into these groups:
 
-| Group | Recipes |
-|-------|---------|
-| dev | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
-| test | `test`, `test-watch`, `test-coverage` |
-| lint | `lint`, `format`, `typecheck` |
-| build | `build`, `docker-build` |
-| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell` |
+| Group    | Recipes                                          |
+| -------- | ------------------------------------------------ |
+| dev      | `dev`, `dev-db`, `dev-services`, `logs`, `shell` |
+| test     | `test`, `test-watch`, `test-coverage`            |
+| lint     | `lint`, `format`, `typecheck`                    |
+| build    | `build`, `docker-build`                          |
+| database | `db-migrate`, `db-seed`, `db-reset`, `db-shell`  |
 
 ## Pre-commit Hooks
 
 Common hooks across FVH application repos:
 
-| Hook | Purpose |
-|------|---------|
-| `commitizen` | Enforce conventional commit messages |
-| `biome` / `ruff` | Language-specific linting and formatting |
-| `detect-secrets` | Prevent accidental secret commits |
-| `check-yaml` / `trailing-whitespace` | General file hygiene |
-| `helm-lint` | Validate Helm values (if `deploy/` exists) |
+| Hook                                 | Purpose                                    |
+| ------------------------------------ | ------------------------------------------ |
+| `commitizen`                         | Enforce conventional commit messages       |
+| `biome` / `ruff`                     | Language-specific linting and formatting   |
+| `detect-secrets`                     | Prevent accidental secret commits          |
+| `check-yaml` / `trailing-whitespace` | General file hygiene                       |
+| `helm-lint`                          | Validate Helm values (if `deploy/` exists) |
 
 Install and run:
 
@@ -55,13 +57,28 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Pre-commit Config Gotchas
+
+A red `pre-commit` / "Code Quality" CI job often traces to the hook _config_,
+not the code. These three hit FVH app repos and are config fixes, not file edits:
+
+| Symptom                                                                   | Root cause                                                                                                                                                                                                        | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| biome: `Found a nested root configuration`                                | A subdir config (e.g. `react_ui/biome.json`) run with `--config-path` from the repo root is treated as a second root config under biome 2.x                                                                       | Add `"root": false` to the nested config **and** drop `--config-path` from the hook `entry` so biome auto-discovers per file (the two are mutually exclusive — `--config-path` requires a root config) |
+| yamllint: `wrong indentation: expected N but found N-2` on every sequence | Helm/k8s values align block sequences with their parent key; the default `indent-sequences: true` rejects that style                                                                                              | Set `indentation: {indent-sequences: consistent}` in `.yamllint` — workflows indent, values don't; both stay internally consistent                                                                     |
+| check-yaml: `Failed` on a `deploy/*values.yaml`                           | A **duplicate top-level key** (ruamel rejects dup keys). YAML last-wins silently dropped the first block — e.g. a second `migrations:` overriding the first's `migrations.image` that ArgoCD Image Updater tracks | Merge the duplicated key's blocks into one, preserving the path Image Updater writes to (`migrations.image.tag`)                                                                                       |
+
+When the fix is on the hook config, also bump any `additional_dependencies`
+version pin to match the config's `$schema` (e.g. biome `2.3.14`), and verify
+with `pre-commit run <hook-id> --all-files` before pushing.
+
 ## Local ↔ CI Parity
 
 **Aspiration, not a hard rule.** When adding or changing a quality gate (linter, formatter, type check, test tier), prefer configurations where the local command and the CI step run the same checks. This prevents the "passes locally, fails in CI" footgun.
 
 Concrete patterns that help:
 
-- A `just lint` / `just test` recipe that invokes the *same* command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
+- A `just lint` / `just test` recipe that invokes the _same_ command as the corresponding CI step (e.g. `ruff check` **and** `ruff format --check`, not just one).
 - Pre-commit hooks mirror the CI lint/format jobs so `pre-commit run --all-files` catches what CI would catch.
 - When CI adds a new check, update the matching local recipe in the same PR.
 


### PR DESCRIPTION
## Summary

Output of one `rulesync generate` run. Two independent concerns bundled because they share the generator pass:

1. **New rule content** — adds a **Pre-commit Config Gotchas** section to `local-development` (canonical source `.rulesync/rules/local-development.md`), documenting three real FVH pre-commit failures and their *config* fixes:
   - biome `Found a nested root configuration` → `"root": false` + drop `--config-path`
   - yamllint sequence-indentation errors → `indent-sequences: consistent`
   - check-yaml `Failed` on `deploy/*values.yaml` → duplicate top-level key
2. **Stale-output catch-up** — regenerates the `github-metadata-hygiene` per-tool files, which were never re-generated after #58 added the `project:cost-attribution` routing row to the source. The `.rulesync` source is unchanged here; only the generated outputs sync (+1 line each).

The remaining diff bulk is prettier reformatting (table alignment, frontmatter `globs:` wrap) with no semantic change.

## Provenance

The real edit lives in `.rulesync/rules/local-development.md`; the four target trees (`.claude/`, `.cursor/`, `.gemini/`, `.github/instructions/`) are generated. New section verified present in all four targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)