### PR TITLE
docs(rules): disambiguate simpl-eval routing to TFDS, not Application Evaluator

### DIFF
--- a/.rulesync/rules/github-metadata-hygiene.md
+++ b/.rulesync/rules/github-metadata-hygiene.md
@@ -48,9 +48,9 @@ Match context to the appropriate org project. Use repository name, file paths, a
 | 2 | Reusable Workflow Migration | `project:reusable-workflows` | CI/CD workflows, `.github/workflows/`, reusable workflow adoption |
 | 3 | Template: Epic | — | Epic-level planning and tracking |
 | 4 | Gateway API Migration | `project:gateway-migration` | Gateway, ingress, networking changes |
-| 5 | TFDS | `project:tfds` | TFDS application and related services |
+| 5 | TFDS | `project:tfds` | TFDS application and related services; **SIMPL-Open / `simpl-eval` / `simpl-eval-common` / the `gke-simpl-eval` cluster** (cost code 313) |
 | 6 | Thelma | `project:thelma` | Theme, UI, design system work |
-| 7 | Application Evaluator | `project:app-evaluator` | Application evaluation tooling |
+| 7 | Application Evaluator | `project:app-evaluator` | The "Application Evaluator" tool/app specifically — **NOT `simpl-eval`** (the `eval` token is a name collision; SIMPL-Open evaluation infra is TFDS, row 5) |
 | 8 | R4C Digital Twin | `project:r4c` | R4C, Cesium, 3D visualization |
 | 9 | Platform Automation | `project:platform-automation` | Terraform, ArgoCD, platform tooling, infrastructure repo |
 | 10 | Kyverno Policies | `project:kyverno` | Security policies, admission control |


### PR DESCRIPTION
## Summary

The agent-side project-determination table in `github-metadata-hygiene.md` routed `simpl-eval` issues to the **Application Evaluator** project (row 7) via a name collision on the `eval` token. `simpl-eval` is the SIMPL-Open evaluation deployment under **TFDS** (cost code 313, `gke-simpl-eval` cluster) — not the Application Evaluator tool.

This adds explicit SIMPL-Open signals to the TFDS row (5) and a `NOT simpl-eval` guard to the Application Evaluator row (7).

## Already remediated

Mislabeled issues corrected in `infrastructure` before this PR (`project:app-evaluator` → `project:tfds`): #2103, #2104, #2058, #2099, #1796.

## Propagation

Source-only change. App repos pick it up via `rulesync fetch` + `generate` in `reusable-sync-ai-rules.yml`; the workspace `.claude/rules/` copy regenerates from this source.

## Test plan

- [ ] `simpl-eval` issues now route to `project:tfds`, not `project:app-evaluator`
- [ ] Sync workflow regenerates tool-specific files without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)