### PR TITLE
fix: handle emoji-prefixed PR titles in conventional commits enforcer

### DIFF
--- a/.github/workflows/reusable-enforce-conventional-commits.yml
+++ b/.github/workflows/reusable-enforce-conventional-commits.yml
@@ -2,7 +2,8 @@ name: Enforce Conventional Commits (Reusable)
 
 # Auto-fixes PR titles to follow the conventional commits specification.
 # Maps common verbs (e.g., "Add", "Fixed", "Upgrade") to canonical types
-# (feat, fix, build, etc.) and updates the title. Fails with a helpful
+# (feat, fix, build, etc.) and updates the title. Strips leading emoji and
+# decorative characters, moving them into the subject. Fails with a helpful
 # message if the title cannot be auto-fixed.
 #
 # Calling workflow should trigger on:
@@ -122,20 +123,47 @@ jobs:
             const VALID_PATTERN = /^(feat|fix|perf|refactor|docs|chore|ci|test|style|build|revert)(\([^)]+\))?!?: .+/;
 
             function attemptFix(title) {
+              // Strip leading non-letter characters (emoji, decorative symbols,
+              // punctuation, whitespace) so titles like "🚀 feat: ..." or
+              // "🚀 Add ..." are handled. Preserved decorations are moved into
+              // the subject to retain the author's intent.
+              const decorations = (title.match(/^([^A-Za-z]*)/)[1] || '').trim();
+              const cleaned = title.replace(/^[^A-Za-z]+/, '');
+
+              if (!cleaned) {
+                // Title contains no letters — cannot determine a type
+                return { fixed: title, changed: false, reason: null };
+              }
+
+              // Insert preserved decorations after the ": " in a conventional title
+              const withDecorations = (conventionalTitle) => {
+                if (!decorations) return conventionalTitle;
+                return conventionalTitle.replace(
+                  /^((?:[A-Za-z]+)(?:\([^)]*\))?(?:!)?: )(.+)$/,
+                  `$1${decorations} $2`
+                );
+              };
+
               // Already valid
-              if (VALID_PATTERN.test(title)) {
-                return { fixed: title, changed: false, reason: 'Already valid' };
+              if (VALID_PATTERN.test(cleaned)) {
+                const fixed = withDecorations(cleaned);
+                return {
+                  fixed,
+                  changed: fixed !== title,
+                  reason: decorations ? 'Moved leading emoji/decorations into subject' : 'Already valid',
+                };
               }
 
               // Pattern: word(scope)?: subject  OR  word: subject  (with any casing / alias)
               const colonPattern = /^([A-Za-z]+)(\([^)]*\))?(!)?: (.+)$/;
-              const colonMatch = title.match(colonPattern);
+              const colonMatch = cleaned.match(colonPattern);
               if (colonMatch) {
                 const [, typePart, scope, bang, subject] = colonMatch;
                 const lower = typePart.toLowerCase();
                 const resolved = VALID_TYPES.includes(lower) ? lower : allAliases[lower];
                 if (resolved) {
-                  const fixed = `${resolved}${scope || ''}${bang || ''}: ${subject}`;
+                  let fixed = `${resolved}${scope || ''}${bang || ''}: ${subject}`;
+                  fixed = withDecorations(fixed);
                   return {
                     fixed,
                     changed: fixed !== title,
@@ -145,15 +173,17 @@ jobs:
               }
 
               // Pattern: verb at start of sentence ("Add feature X", "Fixed bug Y")
-              const words = title.trim().split(/\s+/);
+              const words = cleaned.trim().split(/\s+/);
               if (words.length >= 2) {
                 const first = words[0].toLowerCase().replace(/:$/, '');
                 const resolved = VALID_TYPES.includes(first) ? first : allAliases[first];
                 if (resolved) {
                   const rest = words.slice(1).join(' ');
                   const subject = rest.charAt(0).toLowerCase() + rest.slice(1);
+                  let fixed = `${resolved}: ${subject}`;
+                  fixed = withDecorations(fixed);
                   return {
-                    fixed: `${resolved}: ${subject}`,
+                    fixed,
                     changed: true,
                     reason: `Inferred type "${resolved}" from leading word "${words[0]}"`,
                   };


### PR DESCRIPTION
## Summary

The conventional-commits enforcer workflow (`reusable-enforce-conventional-commits.yml`) failed when a PR title started with an emoji (e.g. `🚀 feat: add thing`). This PR fixes `attemptFix` so emoji-prefixed titles are normalized instead of rejected.

## What

The `attemptFix` function in the enforcer rejected valid PR titles that began with a non-letter character such as an emoji. Titles like `🚀 feat: add thing` or `🚀 Add new feature` failed validation and the workflow called `core.setFailed()`, even though the author clearly intended a conventional-commits title.

## Why

All three of `attemptFix`'s pattern-matching stages required the title to start with ASCII letters:

1. The "already valid" check (`VALID_PATTERN`) was anchored with `^` against the raw title, so `🚀 feat: ...` never matched.
2. The `colonPattern` (`^([A-Za-z]+)(\([^)]*\))?(!)?: (.+)$`) was also anchored at the first ASCII letter.
3. The verb-at-start-of-sentence stage split the raw title, leaving the emoji as the leading "word", so the leading verb was never recognized.

As a result, any emoji-prefixed title fell through to `core.setFailed('Could not auto-fix PR title to conventional commits format')`, blocking the PR.

## How

The fix introduces a normalization step at the top of `attemptFix`:

- **Strip leading non-letter decorations** — capture the leading run of non-ASCII-letter characters (`/^([^A-Za-z]*)/`) and `.trim()` them into a `decorations` string. Remove that leading run from a `cleaned` copy of the title.
- **Run the existing three-stage fix logic on `cleaned`** — the "already valid", `colonPattern`, and verb-at-start stages now operate on the letter-led title, so they match the same cases they always did.
- **Re-insert preserved decorations into the subject** — a `withDecorations()` helper moves the captured decorations to **after** the `: ` separator in the resulting conventional title (e.g. `feat: 🚀 add thing`), preserving the author's intent rather than deleting the emoji.
- **No-letters fallback** — if `cleaned` is empty (the title contains no ASCII letters at all), the original title is returned unchanged with `changed: false`, since no conventional type can be inferred.

The `reason` string now distinguishes "Moved leading emoji/decorations into subject" from the plain "Already valid" case.

## Behavior examples

| Input | Output |
|---|---|
| `🚀 feat: add thing` | `feat: 🚀 add thing` |
| `🚀 Add new feature` | `feat: 🚀 new feature` |
| `✨ feat(auth): add OAuth` | `feat(auth): ✨ add OAuth` |
| `feat: add thing` | unchanged |

## Verification

- `actionlint` passes on the modified workflow.
- 10/10 Node.js test cases pass, covering emoji-prefixed titles, multi-emoji prefixes, no-space-after-emoji variants, already-valid titles, letter-only edge cases, and the no-letters fallback.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
