### PR TITLE
feat(workflows): diff-size skip gate + truncation visibility for Claude analysis workflows

### DIFF
--- a/.github/workflows/reusable-a11y-aria.yml
+++ b/.github/workflows/reusable-a11y-aria.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
     outputs:
       issues-found:
         description: 'Total ARIA issues detected'
@@ -37,9 +67,10 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.scan.outputs.total }}
-      critical: ${{ steps.scan.outputs.critical }}
+      count: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').total_issues }}
+      critical: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').critical_issues }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,29 +82,63 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="ARIA Patterns: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="ARIA Patterns: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude ARIA Analysis
         id: scan
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_issues":{"type":"integer","description":"Total ARIA issues detected"},"critical_issues":{"type":"integer","description":"Critical ARIA misuse issues"}},"required":["total_issues","critical_issues"]}'
           prompt: |
             Audit ARIA implementation in changed components.
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Invalid Roles (Critical)
             - Invalid role values or typos
@@ -123,10 +188,7 @@ jobs:
 
             Reference: https://www.w3.org/WAI/ARIA/apg/patterns/
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_ISSUES: <number>
-            CRITICAL_ISSUES: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_issues (all issues) and critical_issues (critical severity only).
 
             Leave a PR comment with findings grouped by severity.

--- a/.github/workflows/reusable-a11y-wcag.yml
+++ b/.github/workflows/reusable-a11y-wcag.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude turns'
         required: false
         type: number
-        default: 6
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
       wcag-level:
         description: 'WCAG conformance level (A, AA, AAA)'
         required: false
@@ -45,10 +75,11 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.scan.outputs.total }}
-      level-a: ${{ steps.scan.outputs.level-a }}
-      level-aa: ${{ steps.scan.outputs.level-aa }}
+      count: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').total_issues }}
+      level-a: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').level_a_issues }}
+      level-aa: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').level_aa_issues }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -60,30 +91,64 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="WCAG Compliance: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="WCAG Compliance: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude WCAG Analysis
         id: scan
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_issues":{"type":"integer","description":"Total WCAG violations detected"},"level_a_issues":{"type":"integer","description":"Level A violations"},"level_aa_issues":{"type":"integer","description":"Level AA violations"}},"required":["total_issues","level_a_issues","level_aa_issues"]}'
           prompt: |
             Review frontend changes for WCAG 2.1 ${{ inputs.wcag-level }} compliance.
             Focus on static code analysis patterns.
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Level A (Critical - Must Fix)
 
@@ -146,11 +211,7 @@ jobs:
 
             Prioritize Level A issues at the top.
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_ISSUES: <number>
-            LEVEL_A: <number>
-            LEVEL_AA: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_issues (all violations), level_a_issues, and level_aa_issues.
 
             Leave a PR comment with findings grouped by WCAG level.

--- a/.github/workflows/reusable-quality-async.yml
+++ b/.github/workflows/reusable-quality-async.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
     outputs:
       issues-found:
         description: 'Total async pattern issues'
@@ -37,9 +67,10 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.scan.outputs.total }}
-      rejections: ${{ steps.scan.outputs.rejections }}
+      count: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').total_issues }}
+      rejections: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').unhandled_rejections }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,29 +82,63 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="Async Pattern Validation: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="Async Pattern Validation: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude Async Pattern Analysis
         id: scan
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_issues":{"type":"integer","description":"Total async pattern issues found"},"unhandled_rejections":{"type":"integer","description":"Potential unhandled promise rejections"}},"required":["total_issues","unhandled_rejections"]}'
           prompt: |
             Review async code patterns for potential issues.
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Critical Issues (Unhandled Rejections)
             - Floating promises: returned but not awaited, stored, or chained
@@ -102,10 +167,7 @@ jobs:
             - **Risk** - What could go wrong
             - **Fix** - How to handle properly with code example
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_ISSUES: <number>
-            UNHANDLED_REJECTIONS: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_issues (all issues) and unhandled_rejections (potential unhandled rejections).
 
             Leave a PR comment with findings grouped by severity.

--- a/.github/workflows/reusable-quality-code-smell.yml
+++ b/.github/workflows/reusable-quality-code-smell.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
       severity-threshold:
         description: 'Minimum severity to report (low, medium, high)'
         required: false
@@ -42,9 +72,10 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.scan.outputs.total }}
-      high: ${{ steps.scan.outputs.high }}
+      count: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').total_issues }}
+      high: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').high_severity }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,30 +87,64 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="Code Smell Detection: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="Code Smell Detection: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude Code Smell Analysis
         id: scan
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_issues":{"type":"integer","description":"Total code smells detected"},"high_severity":{"type":"integer","description":"High severity issues"}},"required":["total_issues","high_severity"]}'
           prompt: |
             Analyze these files for code smells and anti-patterns.
             Minimum severity to report: ${{ inputs.severity-threshold }}
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Complexity Smells (High Severity)
             - Functions over 50 lines / single responsibility violations
@@ -111,10 +176,7 @@ jobs:
 
             Group findings by severity (high first).
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_ISSUES: <number>
-            HIGH_SEVERITY: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_issues (all issues) and high_severity (high severity only).
 
             Leave a PR comment with findings, grouping by file then severity.

--- a/.github/workflows/reusable-quality-typescript.yml
+++ b/.github/workflows/reusable-quality-typescript.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
       strict-mode:
         description: 'Enforce strict type checking'
         required: false
@@ -42,9 +72,10 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      any: ${{ steps.scan.outputs.any-count }}
-      total: ${{ steps.scan.outputs.total }}
+      any: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').any_count }}
+      total: ${{ fromJSON(steps.scan.outputs.structured_output || '{}').total_issues }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,30 +87,64 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="TypeScript Strictness: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="TypeScript Strictness: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude TypeScript Analysis
         id: scan
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"any_count":{"type":"integer","description":"Number of explicit any usages found"},"total_issues":{"type":"integer","description":"Total type safety issues found"}},"required":["any_count","total_issues"]}'
           prompt: |
             Review TypeScript changes for type safety issues.
             Strict mode: ${{ inputs.strict-mode }}
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Critical Issues (Block Merge in Strict Mode)
             - Explicit `any` usage: `const data: any`, `as any`, function params typed as any
@@ -110,10 +175,7 @@ jobs:
             - **Current** - The problematic code
             - **Suggested** - Type-safe alternative
 
-            At the end, output machine-readable counts:
-            ```
-            ANY_COUNT: <number>
-            TOTAL_ISSUES: <number>
-            ```
+            Report the final counts in the structured output fields:
+            any_count (explicit any usages) and total_issues (all issues).
 
             Leave a PR comment with findings grouped by severity.

--- a/.github/workflows/reusable-security-deps.yml
+++ b/.github/workflows/reusable-security-deps.yml
@@ -12,7 +12,37 @@ on:
         description: 'Maximum Claude analysis turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis, or '*' for any bot. Defaults to '*' because dependency PRs are bot-authored and re-runs replay the original bot-sender event"
+        required: false
+        type: string
+        default: '*'
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
       fail-on-high:
         description: 'Fail workflow if high/critical vulnerabilities found'
         required: false
@@ -37,9 +67,10 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.analyze.outputs.vulnerabilities }}
-      critical: ${{ steps.analyze.outputs.critical }}
+      count: ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').total_vulnerabilities }}
+      critical: ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').critical_high }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -66,12 +97,33 @@ jobs:
             done
           fi
 
+          # Only pull_request events have a base ref to diff against; the gate is inert otherwise
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # numstat prints '-' for binary files; awk sums those as 0
+            DIFF_LINES=$(git diff --numstat origin/${{ github.base_ref }}...HEAD 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
+          else
+            DIFF_LINES=0
+          fi
+
           echo "lockfiles=$CHANGED" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
           if [ -n "$CHANGED" ]; then
             echo "has_lockfiles=true" >> $GITHUB_OUTPUT
           else
             echo "has_lockfiles=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="Dependency Security Audit: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Node.js
         if: contains(fromJSON('["npm", "bun", "pnpm", "yarn"]'), inputs.package-manager)
@@ -130,16 +182,21 @@ jobs:
 
       - name: Claude Dependency Analysis
         id: analyze
-        if: steps.audit-cmd.outputs.results != ''
+        if: steps.audit-cmd.outputs.results != '' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
           # Dependency PRs are bot-authored (Renovate, release-please). On a
           # re-run GitHub replays the original pull_request event whose sender
           # is the bot, so the action's human-actor guard blocks it without
           # this. Audit-and-comment is read-only with a fixed prompt — safe.
-          allowed_bots: "*"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_vulnerabilities":{"type":"integer","description":"Total vulnerabilities found"},"critical_high":{"type":"integer","description":"Critical and high severity vulnerabilities"}},"required":["total_vulnerabilities","critical_high"]}'
           prompt: |
             Analyze the dependency security audit results for this project.
 
@@ -168,16 +225,13 @@ jobs:
 
             Check transitive dependencies — identify the direct dep that pulls in vulnerable transitive deps.
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_VULNERABILITIES: <number>
-            CRITICAL_HIGH: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_vulnerabilities (all findings) and critical_high (critical + high severity).
 
             Leave a PR comment with findings and recommended actions.
 
       - name: Check for critical/high issues
-        if: inputs.fail-on-high && steps.analyze.outputs.critical > 0
+        if: inputs.fail-on-high && fromJSON(steps.analyze.outputs.structured_output || '{}').critical_high > 0
         run: |
-          echo "::error::Found ${{ steps.analyze.outputs.critical }} critical/high severity vulnerabilities"
+          echo "::error::Found ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').critical_high }} critical/high severity vulnerabilities"
           exit 1

--- a/.github/workflows/reusable-security-owasp.yml
+++ b/.github/workflows/reusable-security-owasp.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude analysis turns'
         required: false
         type: number
-        default: 6
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 50
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
       fail-on-critical:
         description: 'Fail workflow if critical issues found'
         required: false
@@ -42,9 +72,10 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      issue-count: ${{ steps.analyze.outputs.issues }}
-      critical-count: ${{ steps.analyze.outputs.critical }}
+      issue-count: ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').total_issues }}
+      critical-count: ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').critical_issues }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,29 +87,63 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="OWASP Security Scan: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="OWASP Security Scan: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude OWASP Analysis
         id: analyze
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"total_issues":{"type":"integer","description":"Total security issues found"},"critical_issues":{"type":"integer","description":"Critical severity issues found"}},"required":["total_issues","critical_issues"]}'
           prompt: |
             Analyze these files for OWASP Top 10 2021 security vulnerabilities.
 
             ## Files to analyze
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## OWASP Top 10 2021 Categories
 
@@ -144,16 +209,13 @@ jobs:
             - **Code Snippet** - The vulnerable code
             - **Remediation** - How to fix it with code example
 
-            At the end, output machine-readable counts:
-            ```
-            TOTAL_ISSUES: <number>
-            CRITICAL_ISSUES: <number>
-            ```
+            Report the final counts in the structured output fields:
+            total_issues (all issues) and critical_issues (critical severity only).
 
             Leave a PR comment with findings grouped by severity (Critical first).
 
       - name: Check for critical issues
-        if: inputs.fail-on-critical && steps.analyze.outputs.critical > 0
+        if: inputs.fail-on-critical && fromJSON(steps.analyze.outputs.structured_output || '{}').critical_issues > 0
         run: |
-          echo "::error::Found ${{ steps.analyze.outputs.critical }} critical security issues"
+          echo "::error::Found ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').critical_issues }} critical security issues"
           exit 1

--- a/.github/workflows/reusable-security-secrets.yml
+++ b/.github/workflows/reusable-security-secrets.yml
@@ -12,12 +12,42 @@ on:
         description: 'Maximum Claude analysis turns'
         required: false
         type: number
-        default: 5
+        default: 50
+      model:
+        description: 'Claude model to use'
+        required: false
+        type: string
+        default: 'haiku'
+      allowed-bots:
+        description: "Comma-separated bot usernames allowed to trigger analysis (e.g. 'renovate[bot]')"
+        required: false
+        type: string
+        default: ''
+      use-sticky-comment:
+        description: 'Maintain a single PR comment instead of posting a new comment per run'
+        required: false
+        type: boolean
+        default: true
+      max-budget-usd:
+        description: 'Maximum spend per run in USD (0 = no budget limit)'
+        required: false
+        type: number
+        default: 0
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 30
       file-limit:
         description: 'Maximum number of changed files to analyze'
         required: false
         type: number
         default: 50
+      max-diff-lines:
+        description: 'Skip Claude analysis when the total PR diff exceeds this many lines (0 disables the gate)'
+        required: false
+        type: number
+        default: 3000
     outputs:
       secrets-found:
         description: 'Number of potential secrets detected'
@@ -34,8 +64,9 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
-      count: ${{ steps.analyze.outputs.secrets }}
+      count: ${{ fromJSON(steps.analyze.outputs.structured_output || '{}').secrets_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,29 +78,63 @@ jobs:
         run: |
           set -f
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="origin/${{ github.base_ref }}...HEAD"
           else
-            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} 2>/dev/null | head -n ${{ inputs.file-limit }} || echo "")
+            RANGE="HEAD~1"
           fi
+          ALL_FILES=$(git diff --name-only "$RANGE" -- ${{ inputs.file-patterns }} 2>/dev/null || echo "")
           set +f
+          FILES=$(echo "$ALL_FILES" | head -n ${{ inputs.file-limit }} || true)
+          TOTAL_FILES=$(echo "$ALL_FILES" | grep -c '.' || true)
           FILE_COUNT=$(echo "$FILES" | grep -c '.' || true)
+          # numstat prints '-' for binary files; awk sums those as 0
+          DIFF_LINES=$(git diff --numstat "$RANGE" 2>/dev/null | awk '{s+=$1+$2} END {print s+0}' || true)
           echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "diff_lines=$DIFF_LINES" >> $GITHUB_OUTPUT
+          echo "total_files=$TOTAL_FILES" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.max-diff-lines }}" -gt 0 ] && [ "$DIFF_LINES" -gt "${{ inputs.max-diff-lines }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          if [ "$TOTAL_FILES" -gt "${{ inputs.file-limit }}" ]; then
+            echo "truncated=true" >> $GITHUB_OUTPUT
+            MSG="Secrets Detection: analyzing only the first ${{ inputs.file-limit }} of $TOTAL_FILES matched files"
+            echo "::notice::$MSG"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "truncated=false" >> $GITHUB_OUTPUT
+          fi
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Diff-size skip notice
+        if: steps.changed.outputs.skip == 'true'
+        run: |
+          MSG="Secrets Detection: skipping Claude analysis — PR diff ${{ steps.changed.outputs.diff_lines }} lines exceeds max-diff-lines ${{ inputs.max-diff-lines }}"
+          echo "::notice::$MSG"
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Claude Secrets Scan
         id: analyze
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model haiku --max-turns ${{ inputs.max-turns }}"
+          allowed_bots: ${{ inputs.allowed-bots }}
+          use_sticky_comment: ${{ inputs.use-sticky-comment }}
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --max-turns ${{ inputs.max-turns }}
+            ${{ inputs.max-budget-usd > 0 && format('--max-budget-usd {0}', inputs.max-budget-usd) || '' }}
+            --json-schema '{"type":"object","properties":{"secrets_count":{"type":"integer","description":"Number of potential secrets detected"}},"required":["secrets_count"]}'
           prompt: |
             CRITICAL: Scan for leaked secrets and credentials in these files.
 
             ## Files to scan
             ${{ steps.changed.outputs.files }}
+            ${{ steps.changed.outputs.truncated == 'true' && 'NOTE: the analyzed file list was truncated — say so in your comment.' || '' }}
 
             ## Secret Patterns to Detect
 
@@ -116,7 +181,7 @@ jobs:
 
             If NO secrets found, respond: "✅ No secrets detected in scanned files."
 
-            At the end, output a machine-readable count:
-            `SECRETS_COUNT: <number>`
+            Report the number of potential secrets found in the structured
+            output field secrets_count.
 
             Leave a PR comment summarizing findings with severity breakdown.


### PR DESCRIPTION
## Why

The Claude-powered analysis workflows (`quality-*`, `security-*`, `a11y-*`) exhaust their turn budget and fail with `error_max_turns` on large PR diffs — infra flakiness, not real findings (#79). This backports the resilience improvements that landed in `laurigates/.github` first, so budget exhaustion is prevented rather than surfaced as a red check.

## What changed (per workflow)

- **`max-diff-lines` input** (default `3000`) — skips Claude analysis when the total PR diff exceeds the threshold (diff-bounded option #3 from #79).
- **Truncation visibility** — `::notice::` + step-summary banner when the matched file list is truncated to `file-limit`.
- **`structured_output`-based job outputs** — replaces fragile text-parsed counts. Existing output names preserved (`issue-count`/`critical-count`/`level-a`/`level-aa`/…), so callers are unaffected.
- **New inputs**: `model`, `timeout-minutes`, `use-sticky-comment`, `max-budget-usd`, `allowed-bots`.
- **`max-turns` default raised 6 → 50** (option #1 from #79).
- `fail-on-critical` gating (owasp) preserved, adapted to `structured_output`.

## Source
`laurigates/.github` commits #33 (`63ae38b`) + #32 (`f10c380`); verified via `just diff-upstream`.

## Sanitization log
**None required** — these 8 files carry no owner-specific tokens (no `laurigates`/`fvh`/self-hosted/service-account refs, no secret names or hardcoded org data).

## Verification
- All 8 files pass `yaml.safe_load` and `actionlint` (exit 0; only pre-existing info-level SC2086 in the ported shell block).
- Model default **kept at `haiku`** on every workflow — pure resilience change, **no model/cost delta**. Reviewer note: laurigates runs these at `sonnet`/`opus`; bumping per-workflow via the new `model` input is a separate, deliberate cost decision.

Closes #79