### PR TITLE
refactor(workflows): switch create-github-app-token to client-id input

### DIFF
--- a/.github/workflows/reusable-auto-merge-image-updater.yml
+++ b/.github/workflows/reusable-auto-merge-image-updater.yml
@@ -25,7 +25,7 @@ on:
         type: string
         default: 'build: automatic image update'
       app-id:
-        description: 'GitHub App ID. When set, generates an App installation token (via APP_PRIVATE_KEY) for PR creation/approval instead of AUTO_MERGE_PAT.'
+        description: 'GitHub App client ID (or numeric App ID; client ID recommended). When set, generates an App installation token (via APP_PRIVATE_KEY) for PR creation/approval instead of AUTO_MERGE_PAT.'
         required: false
         type: string
         default: ''
@@ -52,7 +52,7 @@ jobs:
         if: inputs.app-id != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request

--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: '.release-please-manifest.json'
       app-id:
-        description: 'GitHub App ID. When set, uses an App token (via APP_PRIVATE_KEY) instead of MY_RELEASE_PLEASE_TOKEN.'
+        description: 'GitHub App client ID (or numeric App ID; client ID recommended). When set, uses an App token (via APP_PRIVATE_KEY) instead of MY_RELEASE_PLEASE_TOKEN.'
         required: false
         type: string
         default: ''
@@ -74,7 +74,7 @@ jobs:
         if: inputs.app-id != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v4.4.1

--- a/.github/workflows/reusable-renovate.yml
+++ b/.github/workflows/reusable-renovate.yml
@@ -19,7 +19,7 @@ on:
         type: string
         default: 'false'
       app-id:
-        description: 'Renovate GitHub App ID. When set, generates an App token (via APP_PRIVATE_KEY) instead of using GITHUB_TOKEN.'
+        description: 'Renovate GitHub App client ID (or numeric App ID; client ID recommended). When set, generates an App token (via APP_PRIVATE_KEY) instead of using GITHUB_TOKEN.'
         required: false
         type: string
         default: ''
@@ -78,7 +78,7 @@ jobs:
         if: inputs.app-id != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Why

`actions/create-github-app-token` v3 (the SHA these workflows pin) deprecates the `app-id` input — `deprecationMessage: "Use 'client-id' instead."` — which emits a warning annotation on every run. GitHub's JWT docs likewise recommend the client ID in the `iss` claim.

## What changed

In `reusable-renovate.yml`, `reusable-release-please.yml`, and `reusable-auto-merge-image-updater.yml`:
- The `create-github-app-token` step's `with:` key changes `app-id:` → `client-id:` (same value passed through).
- The `workflow_call` input **names are unchanged** — zero caller impact. Their descriptions now note that either the client ID (recommended) or the numeric App ID is accepted.

## Why this is safe for existing callers

The action's entrypoint resolves `core.getInput("client-id") || core.getInput("app-id")` into a single value handed to `@octokit/auth-app`, which accepts a numeric App ID or an Iv-prefixed client ID interchangeably in the JWT `iss`. Callers currently passing numeric App IDs (e.g. `vars.RENOVATE_APP_ID`) keep working with no secret/variable changes.

## Verification

- All three files pass `yaml.safe_load` and `actionlint -shellcheck=` (exit 0).
- Diff is 6 lines changed per `git show --stat` (3 action-input renames + 3 description updates); job-level `if: inputs.app-id != ''` conditions and token ternaries reference the unchanged workflow inputs and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Yyeb2wVeLvimTDjzMwmp8
