### PR TITLE
[SYNC: laurigates/.github -> ForumViriumHelsinki/.github] Run API-only reusable jobs on ubuntu-slim

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -36,7 +36,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
 | `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
-| `runner` | string | `ubuntu-latest` | Runner label |
+| `runner` | string | `ubuntu-slim` | Runner label — release-please is a pure GitHub-API job |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 

--- a/.cursor/rules/ci-cd-workflows.mdc
+++ b/.cursor/rules/ci-cd-workflows.mdc
@@ -37,7 +37,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
 | `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
-| `runner` | string | `ubuntu-latest` | Runner label |
+| `runner` | string | `ubuntu-slim` | Runner label — release-please is a pure GitHub-API job |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 

--- a/.gemini/memories/ci-cd-workflows.md
+++ b/.gemini/memories/ci-cd-workflows.md
@@ -32,7 +32,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
 | `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
-| `runner` | string | `ubuntu-latest` | Runner label |
+| `runner` | string | `ubuntu-slim` | Runner label — release-please is a pure GitHub-API job |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 

--- a/.github/instructions/ci-cd-workflows.instructions.md
+++ b/.github/instructions/ci-cd-workflows.instructions.md
@@ -36,7 +36,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
 | `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
-| `runner` | string | `ubuntu-latest` | Runner label |
+| `runner` | string | `ubuntu-slim` | Runner label — release-please is a pure GitHub-API job |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 

--- a/.github/workflows/reusable-auto-merge-image-updater.yml
+++ b/.github/workflows/reusable-auto-merge-image-updater.yml
@@ -43,7 +43,8 @@ permissions:
 
 jobs:
   create-and-merge:
-    runs-on: ubuntu-latest
+    # ubuntu-slim: checkout + `gh` PR create/approve/merge, no toolchain.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/reusable-auto-resolve-conflicts.yml
+++ b/.github/workflows/reusable-auto-resolve-conflicts.yml
@@ -43,7 +43,9 @@ permissions:
 
 jobs:
   find-conflicts:
-    runs-on: ubuntu-latest
+    # ubuntu-slim: pure `gh` API calls. The `resolve` job below stays on
+    # ubuntu-latest — it checks out and runs claude-code-action.
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
       has_conflicts: ${{ steps.find.outputs.has_conflicts }}

--- a/.github/workflows/reusable-enforce-conventional-commits.yml
+++ b/.github/workflows/reusable-enforce-conventional-commits.yml
@@ -35,7 +35,8 @@ permissions:
 jobs:
   fix-pr-title:
     name: Fix PR title
-    runs-on: ubuntu-latest
+    # ubuntu-slim: github-script only — no checkout, no toolchain.
+    runs-on: ubuntu-slim
     steps:
       - name: Auto-fix PR title to conventional commits format
         uses: actions/github-script@v8

--- a/.github/workflows/reusable-fix-release-conflicts.yml
+++ b/.github/workflows/reusable-fix-release-conflicts.yml
@@ -41,7 +41,8 @@ permissions:
 
 jobs:
   fix-conflicts:
-    runs-on: ubuntu-latest
+    # ubuntu-slim: pure `gh` API calls, no checkout, no toolchain.
+    runs-on: ubuntu-slim
     steps:
       - name: Wait for release-please to finish
         if: github.event_name == 'push'

--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -22,7 +22,8 @@ on:
         description: 'Runner label'
         required: false
         type: string
-        default: 'ubuntu-latest'
+        # release-please is a pure GitHub-API job — no build, no toolchain.
+        default: 'ubuntu-slim'
       timeout-minutes:
         description: 'Job timeout in minutes'
         required: false

--- a/.rulesync/rules/ci-cd-workflows.md
+++ b/.rulesync/rules/ci-cd-workflows.md
@@ -38,7 +38,7 @@ uses: ForumViriumHelsinki/.github/.github/workflows/<name>.yml@main
 | `config-file` | string | `release-please-config.json` | Path to release-please config file |
 | `manifest-file` | string | `.release-please-manifest.json` | Path to release-please manifest file |
 | `app-id` | string | `''` | GitHub App ID (**preferred**); when set, uses an App token instead of the legacy `MY_RELEASE_PLEASE_TOKEN` PAT |
-| `runner` | string | `ubuntu-latest` | Runner label |
+| `runner` | string | `ubuntu-slim` | Runner label — release-please is a pure GitHub-API job |
 | `timeout-minutes` | number | `15` | Job timeout in minutes |
 | `skip-on-release-commit` | boolean | `false` | Skip when the head commit starts with `chore(main): release` to prevent cascading releases |
 


### PR DESCRIPTION
## The "Why"

Five reusable jobs do **no building**. They call the GitHub API — via `gh`, `actions/github-script`, or release-please — with at most an `actions/checkout`. None needs a language toolchain, `apt`, or a Docker daemon, so the full `ubuntu-latest` image is provisioned and paid for while sitting unused. Moving them to the `ubuntu-slim` tier cuts the per-minute rate for jobs that fire on **every** PR title edit, every release push, and every ArgoCD Image Updater branch — the highest-frequency, lowest-work jobs in the org.

`ubuntu-slim` is not new to this repo: `reusable-claude.yml` already defaults its `runner` input to it, so the label is known-available to the org.

Jobs moved:

| Workflow | Job | What it actually runs |
|---|---|---|
| `reusable-auto-merge-image-updater.yml` | `create-and-merge` | `checkout` + `gh pr create/review/merge` |
| `reusable-enforce-conventional-commits.yml` | `fix-pr-title` | `actions/github-script` only — no checkout |
| `reusable-fix-release-conflicts.yml` | `fix-conflicts` | pure `gh` API calls |
| `reusable-auto-resolve-conflicts.yml` | `find-conflicts` | pure `gh` + `jq` |
| `reusable-release-please.yml` | `runner` input default | release-please action — GitHub API only |

**Deliberately left on `ubuntu-latest`:** the `resolve` job in `reusable-auto-resolve-conflicts.yml`. It checks out the repo and runs `claude-code-action`, so it needs the full image. A comment in the file records why, so the next reader does not "finish the job" and break it.

## Source

`laurigates/.github`, where this landed as laurigates/.github#44 (`ci(workflows): run API-only reusable jobs on ubuntu-slim`).

## Sanitization Log

The ported hunks are runner labels and explanatory comments only — there was nothing personal to scrub. Verified explicitly:

- **Runners** — no `self-hosted` or other environment-specific label involved in either direction; `ubuntu-latest` → `ubuntu-slim` are both GitHub-hosted tiers.
- **Secrets** — no secret name added, removed, or renamed. Every `secrets.*` reference in these files is untouched (`APP_PRIVATE_KEY`, `AUTO_MERGE_PAT`, `MY_RELEASE_PLEASE_TOKEN`, `GITHUB_TOKEN`).
- **Hardcoded data** — **not** ported: laurigates' `reusable-enforce-conventional-commits.yml` carries a `uses: laurigates/.github/...` example in its header comment. FVH's own `ForumViriumHelsinki/...` example is preserved unchanged.
- **Action pins** — **not** ported: laurigates pins `googleapis/release-please-action@v4.4.0`; FVH is on the newer `v4.4.1` and stays there. This backport does not touch any `uses:` line.
- **Metadata** — no ticket numbers, employee names, or internal URLs in the ported text.

## Verification

- `actionlint` on all five touched workflows: **0 findings**, identical to the `origin/main` baseline for the same files.
- All 22 workflow files parse as valid YAML.
- Each moved job was read step-by-step to confirm no `docker`, `apt-get`, `setup-node`/`setup-python`/`setup-go`, or other toolchain dependency — the check that a job's *declared* type cannot answer.
- Only the `runs-on` lines, one input default, and comments changed; no logic, permissions, or step ordering was modified.
- The `runner` row in the release-please input table was updated in the `.rulesync/rules/` source **and** all four generated mirrors, so the documented default matches the code.

No proprietary data exists in this diff.