### PR TITLE
[SYNC: laurigates/.github -> ForumViriumHelsinki/.github] Fix auto-fix passing its prompt via a non-existent input

### DIFF
--- a/.github/workflows/reusable-auto-fix.yml
+++ b/.github/workflows/reusable-auto-fix.yml
@@ -204,7 +204,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot],claude"
           claude_args: ${{ inputs.claude_args }}
-          direct_prompt: |
+          prompt: |
             A GitHub Actions workflow has failed on branch `${{ inputs.branch }}`.
             Your job is to analyze the failure, determine if it can be auto-fixed, and either fix it or open an issue.
 


### PR DESCRIPTION
## The "Why"

`reusable-auto-fix.yml` passes its instructions to `anthropics/claude-code-action@v1` as `direct_prompt:`. **That input does not exist.** The action's `action.yml` declares `prompt:` — `direct_prompt` was the pre-v1 name and appears **zero times** in the current action definition.

GitHub Actions silently discards an undeclared `with:` key. There is no error, no warning in the job summary, and the step still reports success. So the workflow has been invoking Claude with **no instructions at all** — it never received the failure details, the branch name, the run ID, or the fix/open-an-issue decision rule that the prompt body carefully lays out.

This is not theoretical drift: **16 FVH repos call this reusable workflow**, and every one of them has been running a no-op auto-fixer whose whole purpose is to react to CI failures.

The tell that this was an oversight rather than a choice: **every other Claude-powered workflow in this repo already uses `prompt:`** — `reusable-claude-review`, `reusable-security-{secrets,deps,owasp}`, `reusable-quality-{code-smell,async,typescript}`, `reusable-a11y-{aria,wcag}`. `reusable-auto-fix` was the lone straggler on the old name.

## Source

`laurigates/.github`, which made the same correction. Identified here by diffing the two repos' copies of this workflow.

## Sanitization Log

Nothing required scrubbing — the change is a single input key rename (`direct_prompt` → `prompt`); the prompt body itself is untouched. Verified explicitly:

- **Runners** — not touched; the job stays on `ubuntu-latest` (it checks out and runs `claude-code-action`, so it genuinely needs the full image).
- **Secrets** — not touched. `CLAUDE_CODE_OAUTH_TOKEN` is referenced exactly as before.
- **Hardcoded data** — **not** ported: the source file's header carries a `uses: laurigates/.github/...` example; FVH's `ForumViriumHelsinki/...` example is preserved unchanged.
- **Metadata** — no ticket numbers, names, or internal URLs involved.
- **Not ported from the source**: its `--model`/`--max-turns` default changes and its `timeout_minutes` input. Model and turn budget are per-org cost policy and are deliberately left as FVH has them. (The missing job timeout is a real gap — raised separately, not smuggled into a bug fix.)

## Verification

- The input name was checked **against the action's own `action.yml` at HEAD**, not from memory: `direct_prompt` occurs 0 times; `prompt:` is declared at line 57.
- `actionlint` on the modified workflow: **exit 0, zero findings**.
- Caller count (16 repos) measured via `gh api search/code` over the org, excluding this repo's own copies.
- Diff is one line. No logic, permissions, step ordering, or prompt text changed.

No proprietary data exists in this diff.