### PR TITLE
[SYNC: laurigates/.github -> ForumViriumHelsinki/.github] Fix sync-ai-rules fetching zero files silently

### DIFF
--- a/.github/workflows/reusable-sync-ai-rules.yml
+++ b/.github/workflows/reusable-sync-ai-rules.yml
@@ -19,8 +19,20 @@ jobs:
         with:
           node-version: "22"
 
+      # --path .rulesync: rulesync >= 9 resolves features relative to the repo
+      # root of the source repo (GET /contents/rules), so the .rulesync/ layout
+      # must be addressed explicitly or the fetch 404s and returns zero files.
       - name: Fetch rules from .github repo
-        run: npx rulesync@latest fetch ForumViriumHelsinki/.github --features rules,ignore --conflict overwrite
+        run: npx rulesync@latest fetch ForumViriumHelsinki/.github --features rules,ignore --conflict overwrite --path .rulesync
+
+      # fetch exits 0 even when it fetches nothing, and generate then fails
+      # (or silently no-ops) — fail fast with a pointer to the rules source.
+      - name: Verify rules were fetched
+        run: |
+          [ -n "$(find .rulesync/rules -name '*.md' -print -quit 2>/dev/null)" ] || {
+            echo "::error::rulesync fetch produced no rule files — check the .rulesync/rules/ source in ForumViriumHelsinki/.github"
+            exit 1
+          }
 
       - name: Generate tool-specific files
         run: npx rulesync@latest generate


### PR DESCRIPTION
## The "Why"

`reusable-sync-ai-rules.yml` currently fetches **zero rule files on every run** — and reports success.

rulesync >= 9 resolves `--features` relative to the **source repo root**, so the unqualified `fetch` asks for `GET /contents/rules`, gets a `404`, prints "No files found matching enabled features", and **exits 0**. `generate` then has nothing to work from, no diff is produced, and no PR is opened — which is indistinguishable from the healthy outcome "rules already up to date". The sync has been quietly doing nothing.

This was measured against the live repo, not inferred:

| Command | Files fetched |
|---|---|
| current: `rulesync fetch ForumViriumHelsinki/.github --features rules,ignore --conflict overwrite` | **0** (exit 0) |
| fixed: same + `--path .rulesync` | **8** (7 rules + `.aiignore`) |

Two changes:

1. **`--path .rulesync`** — addresses the actual layout, so the fetch resolves.
2. **A fail-fast verify step** — because `fetch` exits 0 on an empty result, a future regression of this exact shape would be silent again. The check fails the job with a message naming the rules source instead of letting an empty sync look healthy.

## ⚠️ This is one of two independent breakages — see #96

Fixing the fetch is **necessary but not sufficient**. `rulesync generate` separately hard-fails because `rulesync.jsonc` and all 7 rule frontmatters pin the `geminicli` target, which current rulesync has removed from its schema.

That second fix is **deliberately not in this PR**: replacing `geminicli` changes which files get generated org-wide (`.gemini/memories/` → `.agents/rules/`) and would orphan committed trees, so it is an org tooling-support decision rather than a mechanical fix. It is filed as #96 with three options.

**Net effect of merging this alone:** the fetch works, and the remaining `generate` failure becomes *loud and attributable* instead of silent. Both are needed to restore the workflow end to end.

## Source

`laurigates/.github`, which hit and fixed the same `--path` problem and added the same fail-fast guard.

## Sanitization Log

- **Hardcoded data — scrubbed.** The source's fetch argument and error message both name `laurigates/.github`; both were rewritten to `ForumViriumHelsinki/.github`. The PR-body text and test-plan checklist in this workflow were left as FVH's.
- **Runners** — not touched; job stays on `ubuntu-latest` (it runs `npx`/Node, so it is not a slim-runner candidate).
- **Secrets** — none added, removed, or renamed.
- **Metadata** — no ticket numbers, employee names, or internal URLs ported.
- **Action pins — deliberately not synced.** The source pins older versions (`actions/checkout` v4.2.2, `create-pull-request` v7.0.8); FVH is on the newer **v4.3.1** and **v7.0.11** and stays there. Confirmed unchanged after the edit — backporting the file wholesale would have been a silent downgrade of two pinned actions.
- **Also not ported:** the source's `--targets claudecode,copilot,antigravity-cli,cursor` on `generate`. That is the #96 decision and does not belong in this PR.

## Verification

- **Both fetch commands were actually executed** against `ForumViriumHelsinki/.github` in a scratch repo — 0 files vs 8 files, as tabulated above. This is a measured result, not a reading of the diff.
- The verify step's shell was executed in both states: **exit 1 with the error annotation** when `.rulesync/rules/` holds no `*.md`, **exit 0** when it does.
- `actionlint` on the modified workflow: **exit 0, zero findings** (includes shellcheck over the new `run:` block).
- Both pinned action SHAs re-checked post-edit and unchanged.

No proprietary data exists in this diff.