### PR TITLE
[SYNC: laurigates/.github -> ForumViriumHelsinki/.github] Add release-please unclog escape hatch

### DIFF
--- a/.github/workflows/reusable-clear-autorelease-labels.yml
+++ b/.github/workflows/reusable-clear-autorelease-labels.yml
@@ -1,0 +1,92 @@
+name: Clear Autorelease Labels (Reusable)
+
+# Manual escape hatch for a clogged release-please pipeline.
+#
+# release-please labels its release PR `autorelease: pending` and only flips
+# it to `autorelease: tagged` once the GitHub release/tag is created. If that
+# release step fails (e.g. a tag ruleset blocks the app), the merged PR stays
+# `pending` forever and every subsequent run re-attempts — and re-fails — the
+# same release. Clearing the stale label on closed PRs lets release-please
+# move on. Run this, then re-run the release-please workflow to unclog.
+#
+# Calling workflow should trigger on:
+#   workflow_dispatch:
+#     inputs:
+#       label:    { ... }
+#       dry_run:  { ... }
+#
+#   jobs:
+#     clear-labels:
+#       uses: ForumViriumHelsinki/.github/.github/workflows/reusable-clear-autorelease-labels.yml@main
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: "Label to strip from closed PRs"
+        required: false
+        type: string
+        default: "autorelease: pending"
+      dry_run:
+        description: "List matches without removing the label"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: clear-autorelease-labels-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  clear-labels:
+    # ubuntu-slim: pure `gh` API calls, no checkout, no toolchain.
+    runs-on: ubuntu-slim
+    steps:
+      - name: Strip label from closed PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          LABEL: ${{ inputs.label }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          echo "Searching closed PRs labelled '$LABEL' in $REPO…"
+          # The issues API returns both issues and PRs; state=closed includes
+          # merged PRs. Keep only entries that are actually pull requests.
+          mapfile -t prs < <(
+            gh api --paginate -X GET "/repos/$REPO/issues" \
+              -f state=closed -f labels="$LABEL" \
+              --jq '.[] | select(.pull_request != null) | .number'
+          )
+
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No closed PRs carry '$LABEL'. Nothing to do."
+            echo "No closed PRs carry \`$LABEL\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### Cleared \`$LABEL\`"
+            echo ""
+            echo "| PR | Action |"
+            echo "| -- | ------ |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for n in "${prs[@]}"; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would remove '$LABEL' from PR #$n"
+              echo "| #$n | dry-run (skipped) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "Removing '$LABEL' from PR #$n"
+              gh pr edit "$n" --repo "$REPO" --remove-label "$LABEL"
+              echo "| #$n | removed |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          echo "Done (${#prs[@]} PR(s))."

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Call these from any FVH repo using `uses: ForumViriumHelsinki/.github/.github/wo
 | `reusable-release-please.yml` | Automated releases via release-please |
 | `reusable-auto-merge-image-updater.yml` | Auto-merge ArgoCD Image Updater PRs (single-job, push-triggered) |
 | `reusable-fix-release-conflicts.yml` | Auto-resolve release-please merge conflicts |
+| `reusable-clear-autorelease-labels.yml` | Manual escape hatch: strip a stale `autorelease: pending` label from closed PRs to unclog release-please |
 | `reusable-renovate.yml` | Dependency updates via Renovate |
 | `reusable-claude.yml` | Claude Code @-mention support in issues and PRs |
 


### PR DESCRIPTION
## The "Why"

`release-please` labels its release PR `autorelease: pending` and only flips it to `autorelease: tagged` once the GitHub release/tag is actually created. When that release step fails — a tag ruleset blocking the app is the usual cause — the merged PR keeps `pending` forever, and **every subsequent release-please run re-attempts and re-fails the same release**. The pipeline is wedged with no self-recovery path.

This adds the manual escape hatch: strip the stale label from closed PRs, then re-run release-please and it moves on to the next version.

Relevant to this org because FVH already runs `reusable-release-please.yml` plus `reusable-fix-release-conflicts.yml` — this covers the one failure mode neither handles.

Design notes:
- **`workflow_dispatch`-driven only.** No schedule, no push trigger — this is a deliberate operator action, not automation.
- **`dry_run` input** (default `false`) lists matches without mutating anything.
- **Filters to real PRs.** The issues API returns issues *and* PRs; the jq keeps only entries with a `pull_request` key.
- Writes a step-summary table so the run record shows exactly which PRs were touched.

## Source

`laurigates/.github` → `.github/workflows/reusable-clear-autorelease-labels.yml` (at `1f14980`). laurigates-only until now; no FVH equivalent existed.

## Sanitization Log

| Item | Action |
|------|--------|
| Usage example in header comment | **Added**, pointing at `ForumViriumHelsinki/.github/...@main` (the source file had no usage block; the added one matches the convention in `reusable-enforce-conventional-commits.yml` and `reusable-claude-review.yml`) |
| Secrets | None to scrub. Uses only the always-available `secrets.GITHUB_TOKEN` — no `RELEASE_PLEASE_TOKEN`, no App credentials, no `secrets:` block to declare |
| Runner label | **Kept as `ubuntu-slim`.** Not a personal/company-specific label — FVH already defaults to `ubuntu-slim` in `reusable-claude.yml` on `main`, and the job is pure `gh` API calls with no checkout or toolchain |
| Hardcoded org data | None present. Repo is read at runtime from `${{ github.repository }}`; the label is an input defaulting to release-please's own `autorelease: pending` |
| Internal references | None. No ticket numbers, employee names, internal URLs, or Artifactory paths in the source file |

Net sanitization diff vs. the laurigates original is **4 added comment lines** (the usage block). The executable body is byte-identical.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses clean; `jobs.clear-labels.runs-on` resolves to `ubuntu-slim`.
- Grepped the file for `laurigates`, `fvh.`, `artifactory`, `self-hosted` — only match is the intentional `ForumViriumHelsinki` usage comment added above.
- Permissions are minimal and match what the steps actually do: `contents: read`, `issues: write`, `pull-requests: write`.
- Logic unchanged from the proven original — the only edit is a comment block.
- Not yet exercised on an FVH repo: it needs a real wedged pipeline, and `dry_run: true` is the safe first invocation.
