### PR TITLE
docs(rules): add runtime GitHub App auth rule

### DIFF
--- a/.claude/rules/github-app-runtime-auth.md
+++ b/.claude/rules/github-app-runtime-auth.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - '**/deploy/values.yaml'
+  - '**/deploy/**'
+  - '**/src/**'
+---
+# Runtime GitHub API Access — Use a GitHub App, Mint Tokens In-Process
+
+## Rule: a deployed app that calls the GitHub API authenticates as a GitHub App installation, minting the installation token inside the process
+
+This covers **runtime** access — an app creating an issue, commenting on a PR,
+or pushing a file while serving a request. GitHub Actions workflows are a
+separate case and use `actions/create-github-app-token`; see
+`ci-cd-workflows.md`.
+
+Two shapes to avoid:
+
+| Shape | Why not |
+|---|---|
+| **PAT in a secret** (`GITHUB_TOKEN`) | Tied to a human account, carries that account's reach rather than a scoped installation, manual rotation |
+| **Pre-minted installation token in a secret** | Installation tokens expire after **60 minutes**; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |
+
+Store the App **private key** instead — long-lived, so the refresh interval
+stops mattering — and let the pod derive short-lived tokens from it.
+
+## Shape
+
+Three env vars, delivered by ExternalSecret from Google Secret Manager:
+
+```yaml
+env:
+  GITHUB_APP_ID:               # the App's client ID
+  GITHUB_APP_INSTALLATION_ID:
+  GITHUB_APP_PRIVATE_KEY:      # PEM
+```
+
+TypeScript — `@octokit/auth-app` handles caching and refresh:
+
+```ts
+new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey, installationId } })
+```
+
+Python — RS256 JWT (`iss` = the App's **client ID**, which GitHub's JWT docs
+recommend over the numeric App ID; `exp` ≤ 10 min) → `POST
+/app/installations/{id}/access_tokens`, cached until shortly before
+`expires_at`. Cache the client or the token, never mint per request.
+
+## Reference implementation
+
+thelma's report-issue feature runs this in-cluster today:
+
+| Piece | Path |
+|---|---|
+| Secrets + IAM + populate instructions | `@infrastructure/gcp/thelma_github_app_secrets.tf` |
+| ExternalSecret + env wiring | `thelma/deploy/values.yaml` (`GITHUB_APP_*`) |
+| In-process minting | `thelma/src/lib/github/feedback-client.ts` |
+
+Full procedure — Terraform triad, `gcloud secrets versions add` commands, apply
+order, Python recipe, verification, traps:
+`@infrastructure/.claude/skills/github-app-runtime-auth/SKILL.md`.
+
+## Two gotchas worth carrying here
+
+- **Apply order.** The `infrastructure-gcp` TFC apply must land *before* the
+  `deploy/values.yaml` change. A `remoteRef` pointing at a secret that does not
+  exist yet leaves the ExternalSecret unable to sync and the pod without the
+  keys.
+- **Fail closed, and loudly.** Check all three env vars up front and disable the
+  feature explicitly (503, or a logged skip) rather than throwing mid-request.
+  Where GitHub errors are deliberately swallowed so they cannot block the
+  primary path, add a metric or alert — otherwise a permanently 403'ing
+  credential is indistinguishable from a working one.

--- a/.cursor/rules/github-app-runtime-auth.mdc
+++ b/.cursor/rules/github-app-runtime-auth.mdc
@@ -1,0 +1,71 @@
+---
+description: Runtime GitHub API access via a GitHub App installation
+globs: **/deploy/values.yaml,**/deploy/**,**/src/**
+---
+
+# Runtime GitHub API Access — Use a GitHub App, Mint Tokens In-Process
+
+## Rule: a deployed app that calls the GitHub API authenticates as a GitHub App installation, minting the installation token inside the process
+
+This covers **runtime** access — an app creating an issue, commenting on a PR,
+or pushing a file while serving a request. GitHub Actions workflows are a
+separate case and use `actions/create-github-app-token`; see
+`ci-cd-workflows.md`.
+
+Two shapes to avoid:
+
+| Shape | Why not |
+|---|---|
+| **PAT in a secret** (`GITHUB_TOKEN`) | Tied to a human account, carries that account's reach rather than a scoped installation, manual rotation |
+| **Pre-minted installation token in a secret** | Installation tokens expire after **60 minutes**; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |
+
+Store the App **private key** instead — long-lived, so the refresh interval
+stops mattering — and let the pod derive short-lived tokens from it.
+
+## Shape
+
+Three env vars, delivered by ExternalSecret from Google Secret Manager:
+
+```yaml
+env:
+  GITHUB_APP_ID:               # the App's client ID
+  GITHUB_APP_INSTALLATION_ID:
+  GITHUB_APP_PRIVATE_KEY:      # PEM
+```
+
+TypeScript — `@octokit/auth-app` handles caching and refresh:
+
+```ts
+new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey, installationId } })
+```
+
+Python — RS256 JWT (`iss` = the App's **client ID**, which GitHub's JWT docs
+recommend over the numeric App ID; `exp` ≤ 10 min) → `POST
+/app/installations/{id}/access_tokens`, cached until shortly before
+`expires_at`. Cache the client or the token, never mint per request.
+
+## Reference implementation
+
+thelma's report-issue feature runs this in-cluster today:
+
+| Piece | Path |
+|---|---|
+| Secrets + IAM + populate instructions | `@infrastructure/gcp/thelma_github_app_secrets.tf` |
+| ExternalSecret + env wiring | `thelma/deploy/values.yaml` (`GITHUB_APP_*`) |
+| In-process minting | `thelma/src/lib/github/feedback-client.ts` |
+
+Full procedure — Terraform triad, `gcloud secrets versions add` commands, apply
+order, Python recipe, verification, traps:
+`@infrastructure/.claude/skills/github-app-runtime-auth/SKILL.md`.
+
+## Two gotchas worth carrying here
+
+- **Apply order.** The `infrastructure-gcp` TFC apply must land *before* the
+  `deploy/values.yaml` change. A `remoteRef` pointing at a secret that does not
+  exist yet leaves the ExternalSecret unable to sync and the pod without the
+  keys.
+- **Fail closed, and loudly.** Check all three env vars up front and disable the
+  feature explicitly (503, or a logged skip) rather than throwing mid-request.
+  Where GitHub errors are deliberately swallowed so they cannot block the
+  primary path, add a metric or alert — otherwise a permanently 403'ing
+  credential is indistinguishable from a working one.

--- a/.gemini/memories/github-app-runtime-auth.md
+++ b/.gemini/memories/github-app-runtime-auth.md
@@ -1,0 +1,66 @@
+# Runtime GitHub API Access — Use a GitHub App, Mint Tokens In-Process
+
+## Rule: a deployed app that calls the GitHub API authenticates as a GitHub App installation, minting the installation token inside the process
+
+This covers **runtime** access — an app creating an issue, commenting on a PR,
+or pushing a file while serving a request. GitHub Actions workflows are a
+separate case and use `actions/create-github-app-token`; see
+`ci-cd-workflows.md`.
+
+Two shapes to avoid:
+
+| Shape | Why not |
+|---|---|
+| **PAT in a secret** (`GITHUB_TOKEN`) | Tied to a human account, carries that account's reach rather than a scoped installation, manual rotation |
+| **Pre-minted installation token in a secret** | Installation tokens expire after **60 minutes**; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |
+
+Store the App **private key** instead — long-lived, so the refresh interval
+stops mattering — and let the pod derive short-lived tokens from it.
+
+## Shape
+
+Three env vars, delivered by ExternalSecret from Google Secret Manager:
+
+```yaml
+env:
+  GITHUB_APP_ID:               # the App's client ID
+  GITHUB_APP_INSTALLATION_ID:
+  GITHUB_APP_PRIVATE_KEY:      # PEM
+```
+
+TypeScript — `@octokit/auth-app` handles caching and refresh:
+
+```ts
+new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey, installationId } })
+```
+
+Python — RS256 JWT (`iss` = the App's **client ID**, which GitHub's JWT docs
+recommend over the numeric App ID; `exp` ≤ 10 min) → `POST
+/app/installations/{id}/access_tokens`, cached until shortly before
+`expires_at`. Cache the client or the token, never mint per request.
+
+## Reference implementation
+
+thelma's report-issue feature runs this in-cluster today:
+
+| Piece | Path |
+|---|---|
+| Secrets + IAM + populate instructions | `@infrastructure/gcp/thelma_github_app_secrets.tf` |
+| ExternalSecret + env wiring | `thelma/deploy/values.yaml` (`GITHUB_APP_*`) |
+| In-process minting | `thelma/src/lib/github/feedback-client.ts` |
+
+Full procedure — Terraform triad, `gcloud secrets versions add` commands, apply
+order, Python recipe, verification, traps:
+`@infrastructure/.claude/skills/github-app-runtime-auth/SKILL.md`.
+
+## Two gotchas worth carrying here
+
+- **Apply order.** The `infrastructure-gcp` TFC apply must land *before* the
+  `deploy/values.yaml` change. A `remoteRef` pointing at a secret that does not
+  exist yet leaves the ExternalSecret unable to sync and the pod without the
+  keys.
+- **Fail closed, and loudly.** Check all three env vars up front and disable the
+  feature explicitly (503, or a logged skip) rather than throwing mid-request.
+  Where GitHub errors are deliberately swallowed so they cannot block the
+  primary path, add a metric or alert — otherwise a permanently 403'ing
+  credential is indistinguishable from a working one.

--- a/.github/instructions/github-app-runtime-auth.instructions.md
+++ b/.github/instructions/github-app-runtime-auth.instructions.md
@@ -1,0 +1,70 @@
+---
+description: Runtime GitHub API access via a GitHub App installation
+applyTo: '**/deploy/values.yaml,**/deploy/**,**/src/**'
+---
+# Runtime GitHub API Access — Use a GitHub App, Mint Tokens In-Process
+
+## Rule: a deployed app that calls the GitHub API authenticates as a GitHub App installation, minting the installation token inside the process
+
+This covers **runtime** access — an app creating an issue, commenting on a PR,
+or pushing a file while serving a request. GitHub Actions workflows are a
+separate case and use `actions/create-github-app-token`; see
+`ci-cd-workflows.md`.
+
+Two shapes to avoid:
+
+| Shape | Why not |
+|---|---|
+| **PAT in a secret** (`GITHUB_TOKEN`) | Tied to a human account, carries that account's reach rather than a scoped installation, manual rotation |
+| **Pre-minted installation token in a secret** | Installation tokens expire after **60 minutes**; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |
+
+Store the App **private key** instead — long-lived, so the refresh interval
+stops mattering — and let the pod derive short-lived tokens from it.
+
+## Shape
+
+Three env vars, delivered by ExternalSecret from Google Secret Manager:
+
+```yaml
+env:
+  GITHUB_APP_ID:               # the App's client ID
+  GITHUB_APP_INSTALLATION_ID:
+  GITHUB_APP_PRIVATE_KEY:      # PEM
+```
+
+TypeScript — `@octokit/auth-app` handles caching and refresh:
+
+```ts
+new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey, installationId } })
+```
+
+Python — RS256 JWT (`iss` = the App's **client ID**, which GitHub's JWT docs
+recommend over the numeric App ID; `exp` ≤ 10 min) → `POST
+/app/installations/{id}/access_tokens`, cached until shortly before
+`expires_at`. Cache the client or the token, never mint per request.
+
+## Reference implementation
+
+thelma's report-issue feature runs this in-cluster today:
+
+| Piece | Path |
+|---|---|
+| Secrets + IAM + populate instructions | `@infrastructure/gcp/thelma_github_app_secrets.tf` |
+| ExternalSecret + env wiring | `thelma/deploy/values.yaml` (`GITHUB_APP_*`) |
+| In-process minting | `thelma/src/lib/github/feedback-client.ts` |
+
+Full procedure — Terraform triad, `gcloud secrets versions add` commands, apply
+order, Python recipe, verification, traps:
+`@infrastructure/.claude/skills/github-app-runtime-auth/SKILL.md`.
+
+## Two gotchas worth carrying here
+
+- **Apply order.** The `infrastructure-gcp` TFC apply must land *before* the
+  `deploy/values.yaml` change. A `remoteRef` pointing at a secret that does not
+  exist yet leaves the ExternalSecret unable to sync and the pod without the
+  keys.
+- **Fail closed, and loudly.** Check all three env vars up front and disable the
+  feature explicitly (503, or a logged skip) rather than throwing mid-request.
+  Where GitHub errors are deliberately swallowed so they cannot block the
+  primary path, add a metric or alert — otherwise a permanently 403'ing
+  credential is indistinguishable from a working one.

--- a/.rulesync/rules/github-app-runtime-auth.md
+++ b/.rulesync/rules/github-app-runtime-auth.md
@@ -1,0 +1,72 @@
+---
+root: false
+targets: ["claudecode", "copilot", "geminicli", "cursor"]
+description: "Runtime GitHub API access via a GitHub App installation"
+globs: ["**/deploy/values.yaml", "**/deploy/**", "**/src/**"]
+---
+# Runtime GitHub API Access — Use a GitHub App, Mint Tokens In-Process
+
+## Rule: a deployed app that calls the GitHub API authenticates as a GitHub App installation, minting the installation token inside the process
+
+This covers **runtime** access — an app creating an issue, commenting on a PR,
+or pushing a file while serving a request. GitHub Actions workflows are a
+separate case and use `actions/create-github-app-token`; see
+`ci-cd-workflows.md`.
+
+Two shapes to avoid:
+
+| Shape | Why not |
+|---|---|
+| **PAT in a secret** (`GITHUB_TOKEN`) | Tied to a human account, carries that account's reach rather than a scoped installation, manual rotation |
+| **Pre-minted installation token in a secret** | Installation tokens expire after **60 minutes**; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |
+
+Store the App **private key** instead — long-lived, so the refresh interval
+stops mattering — and let the pod derive short-lived tokens from it.
+
+## Shape
+
+Three env vars, delivered by ExternalSecret from Google Secret Manager:
+
+```yaml
+env:
+  GITHUB_APP_ID:               # the App's client ID
+  GITHUB_APP_INSTALLATION_ID:
+  GITHUB_APP_PRIVATE_KEY:      # PEM
+```
+
+TypeScript — `@octokit/auth-app` handles caching and refresh:
+
+```ts
+new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey, installationId } })
+```
+
+Python — RS256 JWT (`iss` = the App's **client ID**, which GitHub's JWT docs
+recommend over the numeric App ID; `exp` ≤ 10 min) → `POST
+/app/installations/{id}/access_tokens`, cached until shortly before
+`expires_at`. Cache the client or the token, never mint per request.
+
+## Reference implementation
+
+thelma's report-issue feature runs this in-cluster today:
+
+| Piece | Path |
+|---|---|
+| Secrets + IAM + populate instructions | `@infrastructure/gcp/thelma_github_app_secrets.tf` |
+| ExternalSecret + env wiring | `thelma/deploy/values.yaml` (`GITHUB_APP_*`) |
+| In-process minting | `thelma/src/lib/github/feedback-client.ts` |
+
+Full procedure — Terraform triad, `gcloud secrets versions add` commands, apply
+order, Python recipe, verification, traps:
+`@infrastructure/.claude/skills/github-app-runtime-auth/SKILL.md`.
+
+## Two gotchas worth carrying here
+
+- **Apply order.** The `infrastructure-gcp` TFC apply must land *before* the
+  `deploy/values.yaml` change. A `remoteRef` pointing at a secret that does not
+  exist yet leaves the ExternalSecret unable to sync and the pod without the
+  keys.
+- **Fail closed, and loudly.** Check all three env vars up front and disable the
+  feature explicitly (503, or a logged skip) rather than throwing mid-request.
+  Where GitHub errors are deliberately swallowed so they cannot block the
+  primary path, add a metric or alert — otherwise a permanently 403'ing
+  credential is indistinguishable from a working one.


### PR DESCRIPTION
## What

Adds an org-wide rule, `github-app-runtime-auth`, covering how a **deployed
app** authenticates to the GitHub API at request time: authenticate as a GitHub
App installation and mint the installation token in-process. GitHub Actions
workflows are unaffected — they keep using `actions/create-github-app-token`
(`ci-cd-workflows.md`).

## Why

The convention was unwritten, and both shapes an app might reach for fail
quietly:

| Shape | Failure |
|---|---|
| PAT in a secret | Tied to a human account, carries that account's reach, manual rotation |
| Pre-minted installation token in a secret | Token expires after 60 min; ExternalSecret `refreshInterval` is `1h`, so the delivered token is frequently already dead |

Storing the App **private key** instead makes the refresh interval irrelevant —
the pod derives short-lived tokens from it.

This is not a new design. thelma has run it in-cluster since the report-issue
feature landed (`src/lib/github/feedback-client.ts`, secrets in
`infrastructure/gcp/thelma_github_app_secrets.tf`), and its own code comment
records the pre-minted-token bug as the thing it was avoiding. The rule writes
that down so the next app does not re-derive it — `google-chat-agent`#274 is the
immediate case.

The full procedure (Terraform secret triad, `gcloud secrets versions add`, apply
order, Python minting recipe, verification, traps) lives in a companion skill in
the infrastructure repo: ForumViriumHelsinki/infrastructure#2211.

## Note on the generated files

`npx rulesync@latest generate` currently **fails on this repo** — the configured
`geminicli` target no longer exists in rulesync's target enum, so validation
rejects `rulesync.jsonc` and every rule's frontmatter before generating
anything. Verified pre-existing: it fails identically with this branch's new
rule removed, and on versions back to 9.8.0.

The four generated outputs here were produced by reproducing the generator's
transformation, control-tested to byte-identical output against the committed
`deploy-values` rule (same frontmatter shape) before use.

Two follow-ups filed rather than fixed here, to keep this PR to one concern:
ForumViriumHelsinki/.github#102 (generator broken) and
ForumViriumHelsinki/.github#103 (github-metadata-hygiene's generated outputs are
stale relative to its source).
